### PR TITLE
Corrección del Bug 7 Selección no deseada en las celdas de la tabla

### DIFF
--- a/src/pages/Professor/ProfessorPage.tsx
+++ b/src/pages/Professor/ProfessorPage.tsx
@@ -255,6 +255,23 @@ const hasDeletePermission = HasPermission(deleteProfessorPermission?.name || "")
               columnHeaderTitle: "!font-bold text-center",
             }}
             pageSizeOptions={[5, 10]}
+            checkboxSelection={false}
+            disableRowSelectionOnClick
+            sx={{
+              
+              "& .MuiDataGrid-cell": {
+                userSelect: "none",
+                WebkitUserSelect: "none",
+                MozUserSelect: "none",
+                msUserSelect: "none",
+              },
+              "& .MuiDataGrid-cell:focus": {
+                outline: "none !important",
+              },
+              "& .MuiDataGrid-cell:focus-within": {
+                outline: "none !important",
+              },
+            }}
           />
           <Dialog
             open={open}


### PR DESCRIPTION
Se corrigio el Bug 7, donde no debería ser posible seleccionar celdas en la tabla.
No debería aparecer el mensaje "1 row selected" al hacer clic en una celda.