### PR TITLE
#134 Fix: Columnas de tablas de estudiantes no desproporcionalmente grandes o pequeños

### DIFF
--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -99,7 +99,7 @@ const StudentPage = () => {
       renderCell: (params) => (
         <div>
           {HasPermission(viewStudentReportPermission?.name || "") && (
-                      <IconButton
+          <IconButton
             color="primary"
             aria-label="ver"
             onClick={() => handleView(params.row.id)}
@@ -130,7 +130,7 @@ const StudentPage = () => {
       ),
     },
   ];
-  
+
   const handleCreateTeacher = () => {
     navigate("/create-student");
   };

--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -126,7 +126,6 @@ const StudentPage = () => {
       ),
     },
   ];
-  
   const handleCreateTeacher = () => {
     navigate("/create-student");
   };

--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -53,6 +53,9 @@ const StudentPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      minWidth: 100,
+      maxWidth: 200,
+      resizable: true,
     },
     {
       field: "name",
@@ -60,6 +63,9 @@ const StudentPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      minWidth: 150,
+      maxWidth: 250,
+      resizable: true,
     },
     {
       field: "email",
@@ -67,6 +73,9 @@ const StudentPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      minWidth: 180,
+      maxWidth: 300,
+      resizable: true,
     },
     {
       field: "phone",
@@ -75,6 +84,9 @@ const StudentPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      minWidth: 120,
+      maxWidth: 180,
+      resizable: true,
     },
     {
       field: "actions",
@@ -82,40 +94,42 @@ const StudentPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      minWidth: 150,
+      maxWidth: 200,
       renderCell: (params) => (
         <div>
           {HasPermission(viewStudentReportPermission?.name || "") && (
-          <IconButton
-            color="primary"
-            aria-label="ver"
-            onClick={() => handleView(params.row.id)}
-          >
-            <VisibilityIcon />
-          </IconButton>
+            <IconButton
+              color="primary"
+              aria-label="ver"
+              onClick={() => handleView(params.row.id)}
+            >
+              <VisibilityIcon />
+            </IconButton>
           )}
           {HasPermission(editStudentPermission?.name || "") && (
-          <IconButton
-            color="primary"
-            aria-label="editar"
-            onClick={() => handleEdit(params.row.id)}
-          >
-            <EditIcon />
-          </IconButton>
+            <IconButton
+              color="primary"
+              aria-label="editar"
+              onClick={() => handleEdit(params.row.id)}
+            >
+              <EditIcon />
+            </IconButton>
           )}
           {HasPermission(deleteStudentPermission?.name || "") && (
-          <IconButton
-            color="secondary"
-            aria-label="eliminar"
-            onClick={() => handleClickOpen(params.row.id)}
-          >
-            <DeleteIcon />
-          </IconButton>
+            <IconButton
+              color="secondary"
+              aria-label="eliminar"
+              onClick={() => handleClickOpen(params.row.id)}
+            >
+              <DeleteIcon />
+            </IconButton>
           )}
-          
         </div>
       ),
     },
   ];
+  
 
   const handleCreateTeacher = () => {
     navigate("/create-student");

--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -103,25 +103,19 @@ const StudentPage = () => {
               color="primary"
               aria-label="ver"
               onClick={() => handleView(params.row.id)}
-            ><VisibilityIcon />
-            </IconButton>
-          )}
+            ><VisibilityIcon /></IconButton>)}
           {HasPermission(editStudentPermission?.name || "") && (
             <IconButton
               color="primary"
               aria-label="editar"
               onClick={() => handleEdit(params.row.id)}
-            ><EditIcon />
-            </IconButton>
-          )}
+            ><EditIcon /></IconButton>)}
           {HasPermission(deleteStudentPermission?.name || "") && (
             <IconButton
               color="secondary"
               aria-label="eliminar"
               onClick={() => handleClickOpen(params.row.id)}
-            >DeleteIcon />
-            </IconButton>
-          )}
+            >DeleteIcon /></IconButton>)}
         </div>
       ),
     },

--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -103,8 +103,7 @@ const StudentPage = () => {
               color="primary"
               aria-label="ver"
               onClick={() => handleView(params.row.id)}
-            >
-              <VisibilityIcon />
+            ><VisibilityIcon />
             </IconButton>
           )}
           {HasPermission(editStudentPermission?.name || "") && (
@@ -112,8 +111,7 @@ const StudentPage = () => {
               color="primary"
               aria-label="editar"
               onClick={() => handleEdit(params.row.id)}
-            >
-              <EditIcon />
+            ><EditIcon />
             </IconButton>
           )}
           {HasPermission(deleteStudentPermission?.name || "") && (
@@ -121,8 +119,7 @@ const StudentPage = () => {
               color="secondary"
               aria-label="eliminar"
               onClick={() => handleClickOpen(params.row.id)}
-            >
-              <DeleteIcon />
+            >DeleteIcon />
             </IconButton>
           )}
         </div>
@@ -130,7 +127,6 @@ const StudentPage = () => {
     },
   ];
   
-
   const handleCreateTeacher = () => {
     navigate("/create-student");
   };

--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -99,27 +99,38 @@ const StudentPage = () => {
       renderCell: (params) => (
         <div>
           {HasPermission(viewStudentReportPermission?.name || "") && (
-            <IconButton
-              color="primary"
-              aria-label="ver"
-              onClick={() => handleView(params.row.id)}
-            ><VisibilityIcon /></IconButton>)}
+                      <IconButton
+            color="primary"
+            aria-label="ver"
+            onClick={() => handleView(params.row.id)}
+          >
+            <VisibilityIcon />
+          </IconButton>
+          )}
           {HasPermission(editStudentPermission?.name || "") && (
-            <IconButton
-              color="primary"
-              aria-label="editar"
-              onClick={() => handleEdit(params.row.id)}
-            ><EditIcon /></IconButton>)}
+          <IconButton
+            color="primary"
+            aria-label="editar"
+            onClick={() => handleEdit(params.row.id)}
+          >
+            <EditIcon />
+          </IconButton>
+          )}
           {HasPermission(deleteStudentPermission?.name || "") && (
-            <IconButton
-              color="secondary"
-              aria-label="eliminar"
-              onClick={() => handleClickOpen(params.row.id)}
-            >DeleteIcon /></IconButton>)}
+          <IconButton
+            color="secondary"
+            aria-label="eliminar"
+            onClick={() => handleClickOpen(params.row.id)}
+          >
+            <DeleteIcon />
+          </IconButton>
+          )}
+          
         </div>
       ),
     },
   ];
+  
   const handleCreateTeacher = () => {
     navigate("/create-student");
   };


### PR DESCRIPTION
Ahora las columnas de la pagina de estudiantes no se puede alterar de manera proporcional con una edición de tamaño de columnas máximas y mínimas, así no verse desproporcional, estético y fácil de leer:

### Mínimo:
![image](https://github.com/user-attachments/assets/5aa24c06-5736-4a2e-9b10-67d1d42e431c)

### Máximo:
![image](https://github.com/user-attachments/assets/95ddd6c2-33dd-411f-be89-1c07edd732f7)
