### PR TITLE
La tabla de docentes ahora es responsive

### DIFF
--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -166,7 +166,7 @@ const Layout = () => {
         </Toolbar>
       </AppBar>
       <Sidebar open={open} setOpen={setOpen} />
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+      <Box component="main" sx={{ flexGrow: 1, p: 3, overflowX: 'auto', width: '100%' }}>
         <DrawerHeader />
         <Outlet />
       </Box>

--- a/src/pages/Professor/ProfessorPage.tsx
+++ b/src/pages/Professor/ProfessorPage.tsx
@@ -66,8 +66,7 @@ const ProfessorPage = () => {
       setIsLoading(false);
     };
 
-    fetchPermissions();
-    fetchProfessors();
+    fetchPermissions(); 
   }, []);
 
   const hasViewPermission = HasPermission(


### PR DESCRIPTION
Se solucionó el problema, y ahora es responsive   
![Captura de pantalla 2025-04-04 192630](https://github.com/user-attachments/assets/9eff5878-3703-4ee4-b11e-b00d56912eed)


