### PR TITLE
#226 Boton para volver a la pagina de Students

### DIFF
--- a/src/pages/Student/CreateStudentPage.tsx
+++ b/src/pages/Student/CreateStudentPage.tsx
@@ -145,7 +145,7 @@ const CreateStudentPage = () => {
             </Typography>
             <Divider flexItem sx={{ mt: 2, mb: 2 }} />
           </Grid>
-          
+
           <Grid item xs={12}>
             <Grid container spacing={2} sx={{ padding: 2 }}>
               <Grid item xs={3}>

--- a/src/pages/Student/CreateStudentPage.tsx
+++ b/src/pages/Student/CreateStudentPage.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import { FormContainer } from "../CreateGraduation/components/FormContainer";
+import { useNavigate } from "react-router-dom";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import {
   Button,
   Divider,
@@ -12,6 +14,7 @@ import {
   Alert,
   Switch,
   FormControlLabel,
+  IconButton,
 } from "@mui/material";
 import { createStudent } from "../../services/studentService";
 import SuccessDialog from "../../components/common/SucessDialog";
@@ -43,6 +46,12 @@ const CreateStudentPage = () => {
   const [errorDialog, setErrorDialog] = useState(false);
   const [message, setMessage] = useState("");
   const [severity, setSeverity] = useState<"success" | "error">("success");
+
+  const navigate = useNavigate();
+
+  const handleBackNavigate = () => {
+    navigate("/students");
+  };
 
   const sucessDialogClose = () => {
     setSuccessDialog(false);
@@ -116,6 +125,16 @@ const CreateStudentPage = () => {
   };
 
   return (
+    <Grid container spacing={0} alignItems="center">
+      <Grid container spacing={4} sx={{ padding: 2, position: "relative" }}>
+        <IconButton
+          onClick={handleBackNavigate}
+          aria-label="back"
+          sx={{ position: "absolute", left: 21, top: 60 }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+      </Grid>
     <FormContainer>
       <form onSubmit={formik.handleSubmit}>
         <Grid container spacing={2} sx={{ padding: 2 }}>
@@ -126,7 +145,6 @@ const CreateStudentPage = () => {
             </Typography>
             <Divider flexItem sx={{ mt: 2, mb: 2 }} />
           </Grid>
-
           <Grid item xs={12}>
             <Grid container spacing={2} sx={{ padding: 2 }}>
               <Grid item xs={3}>
@@ -322,6 +340,7 @@ const CreateStudentPage = () => {
         subtitle={message}
       />
     </FormContainer>
+    </Grid>
   );
 };
 

--- a/src/pages/Student/CreateStudentPage.tsx
+++ b/src/pages/Student/CreateStudentPage.tsx
@@ -145,6 +145,7 @@ const CreateStudentPage = () => {
             </Typography>
             <Divider flexItem sx={{ mt: 2, mb: 2 }} />
           </Grid>
+          
           <Grid item xs={12}>
             <Grid container spacing={2} sx={{ padding: 2 }}>
               <Grid item xs={3}>


### PR DESCRIPTION
Se añadió un botón sacado de los estilos de MUI para volver a la pagina de "/students" con su respectivo navigate.

 por razones estéticas se agregó un extra Grid en el return para centrar el formulario al medio de la pagina y poder insertar el botón al lado izquierdo para que no se solape con ningún otro elemento.

![image](https://github.com/user-attachments/assets/204f5764-2f4f-4ead-bf07-7acac79d0c2b)
