### PR TITLE
#249 Todos Los Textos Deben Estar Traducidos En El Idioma Correspondiente Task

### DIFF
--- a/src/pages/graduation/GraduationProcessPage.tsx
+++ b/src/pages/graduation/GraduationProcessPage.tsx
@@ -10,6 +10,7 @@ import { Box, Button, IconButton, Paper } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import VisibilityIcon from "@mui/icons-material/Visibility";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 const GraduationProcessPage = () => {
   const [filteredData, setFilteredData] = useState<Student[] | []>([]);
@@ -134,6 +135,7 @@ const GraduationProcessPage = () => {
           <DataGrid
             rows={filteredData}
             columns={tableHeaders}
+            localeText={dataGridLocaleText}
             initialState={{
               pagination: {
                 paginationModel: { page: 0, pageSize: 5 },


### PR DESCRIPTION
# Bug
Se muestra texto en inglés dentro de la tabla de procesos de graduación:
![image](https://github.com/user-attachments/assets/ede1ae5c-547a-44a3-8b9d-e3555869b282)

# Fix
Se cargaron los textos desde `import dataGridLocaleText from "../../locales/datagridLocaleEs";` y se cargaron al DataGrid de la tabla:
```
localeText={dataGridLocaleText}
```
Ahora el texto se muestra en el idioma correspondiente:
![image](https://github.com/user-attachments/assets/f87c9b3e-f804-4bbb-bc51-c374b0b36f9a)
![image](https://github.com/user-attachments/assets/9adda5f7-6a7c-422e-a519-29fa8b14261e)

>[!Tip]
>Los textos de ordenamiento "Ordenar ascendente" y "Ordenar descendente" suenan incompletos, consultar con los otros equipos Frontend si es posible hacer un cambio sin interferir con otros módulos.