### PR TITLE
#254 Posibilidad de Elegir Años Pasados en el Campo de Fecha de Asignación

### DIFF
--- a/src/components/stages/DateSelection.tsx
+++ b/src/components/stages/DateSelection.tsx
@@ -5,12 +5,15 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { FormikProps } from "formik";
 import { MentorFormValues } from "../../hooks/useMentorFormik";
+import dayjs from 'dayjs';
 
 interface DateSelectionProps {
   disabled: boolean;
   formik: FormikProps<MentorFormValues>;
   renderFieldError: (fieldName: string) => JSX.Element | null;
 }
+
+const currentDate = dayjs();
 
 const DateSelection: FC<DateSelectionProps> = ({ disabled, formik, renderFieldError }) => {
   return (
@@ -22,6 +25,8 @@ const DateSelection: FC<DateSelectionProps> = ({ disabled, formik, renderFieldEr
           value={formik.values.date_tutor_assignament}
           onChange={(value) => formik.setFieldValue("date_tutor_assignament", value)}
           format="DD/MM/YYYY"
+          minDate={currentDate}
+          maxDate={currentDate.add(1,'year')}
         />
       </LocalizationProvider>
       {renderFieldError("date_tutor_assignament")}

--- a/src/data/periods.ts
+++ b/src/data/periods.ts
@@ -8,7 +8,7 @@ const setPeriods = () => {
 
   for (let i = 0; i < numberPeriods; i++) {
     let strPeriod = firstSemester ? 'Primero' : 'Segundo'; 
-    let str = strPeriod + ' ' + currentYear; 
+    let str = strPeriod + '-' + currentYear; 
     listPeriods.push({
       id: i + 1, 
       value: str

--- a/src/data/periods.ts
+++ b/src/data/periods.ts
@@ -1,20 +1,26 @@
-export const periods = [
-  {
-    id: 1,
-    value: 'Primero2023',
-  },
-  {
-    id: 2,
-    value: 'Segundo2023',
-  },
-  {
-    id: 3,
-    value: 'Primero2024',
-  },
-  {
-    id: 4,
-    value: 'Segundo2024',
-  },
-];
+const actualDate = new Date();
+const numberPeriods = 3;
 
-export const currentPeriod = 'Primero2024';
+const setPeriods = () => {
+  let firstSemester = actualDate.getMonth() <= 5; 
+  let currentYear = actualDate.getFullYear(); 
+  const listPeriods = [];
+
+  for (let i = 0; i < numberPeriods; i++) {
+    let strPeriod = firstSemester ? 'Primero' : 'Segundo'; 
+    let str = strPeriod + ' ' + currentYear; 
+    listPeriods.push({
+      id: i + 1, 
+      value: str
+    });
+
+    if (!firstSemester) currentYear++; 
+    firstSemester = !firstSemester; 
+  }
+  
+  return listPeriods; 
+};
+
+export const periods = setPeriods();
+
+export const currentPeriod = periods[0].value; 


### PR DESCRIPTION
# Bug
Se presenta selección de periodos pasados en la parte 1 de edición de procesos de graduación:
![image](https://github.com/user-attachments/assets/0059bf2a-8361-4f67-ad5a-b92e22da8711)
Y se presenta la selección de fechas pasadas en la parte 2:
![image](https://github.com/user-attachments/assets/25d721fe-af08-41e1-8407-ea355cc7abbb)

# Fix
Se calculan los periodos venideros y se los muestra correctamente, se sigue la misma estructura clave valor del archivo anterior:
```
const setPeriods = () => {
  let firstSemester = actualDate.getMonth() <= 5; 
  let currentYear = actualDate.getFullYear(); 
  const listPeriods = [];

  for (let i = 0; i < numberPeriods; i++) {
    let strPeriod = firstSemester ? 'Primero' : 'Segundo'; 
    let str = strPeriod + ' ' + currentYear; 
    listPeriods.push({
      id: i + 1, 
      value: str
    });

    if (!firstSemester) currentYear++; 
    firstSemester = !firstSemester; 
  }

  return listPeriods; 
};

export const periods = setPeriods();

export const currentPeriod = periods[0].value; 
```

![image](https://github.com/user-attachments/assets/2bc1fe26-53fc-477d-a3ff-3735124742eb)


>[!Warning]
>La estructura Clave Valor asigna claves estáticas a valores dinámicos con el tiempo, por el momento se mantiene la misma estructura para evitar problemas con otros módulos, pero se recomienda un mejor análisis al modo en que se guardan estos valores.

Para la parte 2 se agregó una fecha mínima y una máxima para definir el intervalo de fechas aceptado, ambos valores son personalizables:
```
          minDate={currentDate}
          maxDate={currentDate.add(1,'year')}
```

![image](https://github.com/user-attachments/assets/856aca12-e8e4-4cf6-b4f2-a4e1524e6911)
![image](https://github.com/user-attachments/assets/525d939d-3aed-42ac-9784-8d7d6fdbd026)

