### PR TITLE
#260 Diferencia en el Color de Letra entre la Parte 1 y la Parte 2

### DIFF
--- a/src/components/stages/MentorStage.tsx
+++ b/src/components/stages/MentorStage.tsx
@@ -94,7 +94,7 @@ export const MentorStage: FC<InternalDefenseStageProps> = ({ onPrevious, onNext 
 
   return (
     <>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="h6"  gutterBottom style={{ fontWeight: 'bold' }}>
         Etapa 2: Seleccionar Tutor <ModeEditIcon onClick={editForm} style={{ cursor: "pointer" }} />
       </Typography>
 

--- a/src/components/stages/RegistrationStage.tsx
+++ b/src/components/stages/RegistrationStage.tsx
@@ -10,6 +10,7 @@ import { periods, currentPeriod } from "../../data/periods";
 import { useProcessStore } from "../../store/store";
 import { updateProcess } from "../../services/processServicer";
 import ModeEditIcon from "@mui/icons-material/ModeEdit";
+import {Typography } from "@mui/material";
 import {
   FormControl,
   FormControlLabel,
@@ -96,9 +97,9 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
 
   return (
     <>
-      <div className="txt1">
-        Etapa 1: Seminario de Grado <ModeEditIcon onClick={editForm} />
-      </div>
+      <Typography variant="h6" gutterBottom style={{ fontWeight: 'bold' }}>
+        Etapa 1: Seminario de Grado <ModeEditIcon onClick={editForm} style={{ cursor: "pointer" }} />
+      </Typography>
 
       <form onSubmit={formik.handleSubmit} className="mt-5 mx-16">
         <Grid container spacing={3}>


### PR DESCRIPTION
# Bug
Las fuentes de los títulos en el seguimiento y edición de procesos de graduación difieren:
![image](https://github.com/user-attachments/assets/4c10e27c-eccb-4a20-8178-72538772b0e4)
![image](https://github.com/user-attachments/assets/acaeadc2-9194-419e-a5f3-a5b952331d92)

# Fix
Cambios menores para adecuar ambos títulos a una misma estética:
```
<Typography variant="h6" gutterBottom style={{ fontWeight: 'bold' }}>
        Etapa 1: Seminario de Grado <ModeEditIcon onClick={editForm} style={{ cursor: "pointer" }} />
      </Typography>
```
```
<Typography variant="h6"  gutterBottom style={{ fontWeight: 'bold' }}>
```

![image](https://github.com/user-attachments/assets/c4c1b819-aa21-45cb-ae37-4f91145ee475)
![image](https://github.com/user-attachments/assets/8a96cbab-67f1-4e3b-ac49-24f4b6777010)
