### PR TITLE
#252 Solicitud de Guardado de Datos Aunque No Existan Cambios Realizados

### DIFF
--- a/src/components/stages/RegistrationStage.tsx
+++ b/src/components/stages/RegistrationStage.tsx
@@ -52,6 +52,7 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [, setError] = useState<any | null>(null);
   const [showModal, setShowModal] = useState<boolean>(false);
+  const [edited, setEdited] = useState(false)
 
   useEffect(() => {
     const fetchData = async () => {
@@ -87,13 +88,22 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
     },
     validationSchema,
     onSubmit: () => {
-      setShowModal(true);
+      if (!edited) {
+        onNext()
+      } else {
+        setShowModal(true)
+      }
     },
   });
 
   const editForm = () => {
     setReadOnly(false);
   };
+
+  const handleOnChange = (event: any) => {
+    setEdited(true)
+    formik.handleChange(event);
+  }
 
   return (
     <>
@@ -111,7 +121,7 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
                 name="mode"
                 row
                 value={formik.values.mode}
-                onChange={formik.handleChange}
+                onChange={handleOnChange}
               >
                 {modes.map((option) => (
                   <FormControlLabel
@@ -132,7 +142,7 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
                 id="period"
                 name="period"
                 value={formik.values.period}
-                onChange={formik.handleChange}
+                onChange={handleOnChange}
                 label="2. Seleccione periodo de inscripción"
                 disabled={readOnly}
                 error={formik.touched.period && Boolean(formik.errors.period)}


### PR DESCRIPTION
# Bug
El modal de confirmación se muestra sin importar si se han realizado cambios en los datos del formulario o no, cuando este debería mostrarse únicamente luego de realizar un cambio en la información:
![image](https://github.com/user-attachments/assets/fb96584e-c4d7-4f8c-a2c8-c395eb5323ec)
![image](https://github.com/user-attachments/assets/679eb2ef-517a-4a10-aa4a-1346928af7c9)

# Fix
Se agregó un estado boolean `edited` inicializado en *false* para tener un mejor control sobre las circunstancias en las que debe mostrarse el modal. Este estado cambiará a *true* cuando se realice cualquier cambio en el formulario:
```
//Dentro de los items del formulario:
onChange={handleOnChange}
```
```
const handleOnChange = (event: any) => {
    setEdited(true)
    formik.handleChange(event);
  }
```

Al momento de presionar el botón para continuar a la siguiente etapa, el valor de edited determinará si se muestra el modal o se pasa a la siguiente página del recorrido:
```
onSubmit: () => {
      if (!edited) {
        onNext()
      } else {
        setShowModal(true)
      }
}
```