### PR TITLE
#261 Falta de Visualización del Periodo en la Inspección Inicial al Crear un Proceso de Graduación

### DIFF
--- a/src/components/stages/RegistrationStage.tsx
+++ b/src/components/stages/RegistrationStage.tsx
@@ -100,7 +100,7 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
       <Typography variant="h6" gutterBottom style={{ fontWeight: 'bold' }}>
         Etapa 1: Seminario de Grado <ModeEditIcon onClick={editForm} style={{ cursor: "pointer" }} />
       </Typography>
-
+  
       <form onSubmit={formik.handleSubmit} className="mt-5 mx-16">
         <Grid container spacing={3}>
           <Grid item xs={12} sm={12} md={7} lg={8}>
@@ -124,7 +124,7 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
               </RadioGroup>
             </FormControl>
           </Grid>
-          <Grid item xs={12} sm={12} md={5} lg={4}>
+          <Grid item xs={12} sm={12} md={7} lg={8}>
             <FormControl fullWidth variant="outlined" margin="normal">
               <InputLabel id="period-label">2. Seleccione periodo de inscripción</InputLabel>
               <Select
@@ -137,9 +137,6 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
                 disabled={readOnly}
                 error={formik.touched.period && Boolean(formik.errors.period)}
               >
-                <MenuItem value="">
-                  <em>Seleccione Periodo</em>
-                </MenuItem>
                 {periods.map((option) => (
                   <MenuItem key={option.id} value={option.id}>
                     {option.value}


### PR DESCRIPTION
# Bug
Al volver a inspeccionar la etapa 1 de los procesos de graduación, el periodo no muestra correctamente su información, aún si el periodo ya se encuentra definido:
![image](https://github.com/user-attachments/assets/ab5d61a0-6722-4031-9ef9-a9d3f1bb3009)

# Fix
El primer item del selector interrumpía la carga del periodo guardado, al borrarlo, se carga correctamente la información. Sin embargo, antes de borrarlo es necesario ver cual era su función.

La función de este primer item del selector era dar una pequeña descripción a esta sección del formulario, función que también cumple el label del mismo selector, por lo que no se pierde demasiado al borrar este item, sin embargo, se le dió más espacio al selector para que pueda mostrar la descripción completa.

![image](https://github.com/user-attachments/assets/c2b1b2cd-ad70-4d70-8a63-3382a8fcbeb2)
![image](https://github.com/user-attachments/assets/8f26d2ba-8a7b-4303-a5f8-0af6d1d67bc0)
