### PR TITLE
fix: agregar botón de retroceso en formulario de crear docente

### DIFF
--- a/src/pages/Professor/CreateProfessorPage.tsx
+++ b/src/pages/Professor/CreateProfessorPage.tsx
@@ -222,8 +222,12 @@ const CreateProfessorPage = () => {
           <Grid item xs={12}>
             <Grid container spacing={2} justifyContent="flex-end">
               <Grid item>
-                <Button variant="contained" color="primary" type="submit">
+                <Button variant="contained" color="primary" type="submit" sx={{ mr: 3 }}>
                   GUARDAR
+                </Button>
+                <Button variant="contained" color="primary" type="button" 
+                onClick={() => window.history.back()}>
+                  CANCELAR
                 </Button>
               </Grid>
             </Grid>


### PR DESCRIPTION
Bug: 
En la pantalla de creación de docente (/create-professor), no existe un botón visible o funcional que permita al usuario regresar a la pantalla anterior. 
<img width="387" alt="Screenshot 2025-04-11 at 8 02 32 PM" src="https://github.com/user-attachments/assets/1b9ab90f-f6db-4697-8952-fcc150f52a19" />
Fix: 
Agregamos un botón CANCELAR para que el usuario pueda volver la anterior pagina 
<img width="673" alt="Screenshot 2025-04-11 at 8 03 27 PM" src="https://github.com/user-attachments/assets/e4a96632-4bcc-4d2a-adb4-06760c556eeb" />
<img width="666" alt="Screenshot 2025-04-11 at 8 03 41 PM" src="https://github.com/user-attachments/assets/7aed1793-c1ca-4f23-9b3b-f31cbf39694b" />
