### PR TITLE
FIX: Modal de agregar estudiante ahora tiene botón para volver atrás (Un botón para cerrar modal)

### DIFF
--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -1,7 +1,7 @@
 import { DataGrid, GridColDef, GridColumnVisibilityModel } from "@mui/x-data-grid";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
-import CloseIcon from "@mui/icons-material/Close";
+import CloseIcon from "@mui/icons-material/ArrowBack";
 import {
   Button,
   IconButton,
@@ -326,7 +326,7 @@ const StudentPage = () => {
             onClick={() => setOpenCreateModal(false)}
             sx={{
               position: "absolute",
-              right: 2,
+              left: 2,
               top: 2,
               "&:hover": {
                 bgcolor: "grey.200",

--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -1,6 +1,7 @@
 import { DataGrid, GridColDef, GridColumnVisibilityModel } from "@mui/x-data-grid";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
+import CloseIcon from "@mui/icons-material/Close";
 import {
   Button,
   IconButton,
@@ -311,17 +312,31 @@ const StudentPage = () => {
           </Dialog>
           <Dialog
             open={openCreateModal}
-            onClose={() => setOpenCreateModal(false)}
             maxWidth="md"
             PaperProps={{
               sx: {
                 borderRadius: 3,
                 p: 0,
                 maxHeight: "100vh",
+                position: "relative",
               },
             }}
           >
-            <DialogContent sx={{ p: 2, m: 0 }}>
+          <IconButton
+            onClick={() => setOpenCreateModal(false)}
+            sx={{
+              position: "absolute",
+              right: 2,
+              top: 2,
+              "&:hover": {
+                bgcolor: "grey.200",
+              },
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+
+            <DialogContent sx={{ p: 2, m: 1 }}>
               <CreateStudentForm onSuccess={handleStudentCreated} />
             </DialogContent>
           </Dialog>


### PR DESCRIPTION
Debido a que antes teníamos una pagina completa para Agregar estudiantes y ahora estamos usando un modal, no se implemento un botón para volver a atrás (BackArrowBtn)... Ahora tiene el boton en la esquina superior izquierda para evitar MissClick y no llenar el formulario de nuevo.

![image](https://github.com/user-attachments/assets/85922e7b-1239-4d8b-ba47-cffffcd0e875)

NOTA: se agrando el margin del modal por estética del boton