### PR TITLE
fix: ajustar redistribución de columnas al ocultar para evitar espaci…

### DIFF
--- a/src/pages/Professor/ProfessorPage.tsx
+++ b/src/pages/Professor/ProfessorPage.tsx
@@ -241,6 +241,21 @@ const ProfessorPage = () => {
     },
   ];
 
+  const getResponsiveColumns = (): GridColDef[] => {
+    const visibleColumns = columns.filter(col => columnVisibilityModel[col.field] !== false && col.field !== 'actions');
+    const dynamicFlex = visibleColumns.length > 0 ? Math.floor(12 / visibleColumns.length) : 1;
+
+    return columns.map(col => {
+      if (col.field === 'actions' || columnVisibilityModel[col.field] === false) return col;
+      return {
+          ...col,
+          flex: dynamicFlex,
+          minWidth: 100,
+          maxWidth: undefined,
+      };
+    });
+  };
+
   const handleCreateTeacher = () => {
     navigate("/create-professor");
   };
@@ -319,7 +334,7 @@ const ProfessorPage = () => {
           <div style={{ width: "100%", paddingBottom: 0 }}>
             <DataGrid
               rows={professors}
-              columns={columns}
+              columns={getResponsiveColumns()}
               localeText={dataGridLocaleText}
               initialState={{
                 pagination: {


### PR DESCRIPTION
# *Bug:*
Cuando se ocultan tres o más columnas en la tabla de docentes, en la parte derecha de la tabla aparece un área en blanco. Este espacio en blanco indica que los datos de las columnas restantes no se están reacomodando para aprovechar el ancho total de la tabla.
![Bug_337](https://github.com/user-attachments/assets/1b990051-7b5d-4eb6-a01b-593a7b888485)
# *Fix:*
Se modificó la lógica que determina el layout de las columnas visibles.
Ahora, la cantidad de columnas activas se calcula dinámicamente, y a partir de ello se asigna un valor proporcional al flex de cada una para que ocupen todo el ancho de la tabla.
- getResponsiveColumns 

const getResponsiveColumns = (): GridColDef[] => {
  const visibleColumns = columns.filter(
    col => columnVisibilityModel[col.field] !== false && col.field !== 'actions'
  );

  const dynamicFlex = visibleColumns.length > 0 ? Math.floor(12 / visibleColumns.length) : 1;

  return columns.map(col => {
    if (col.field === 'actions' || columnVisibilityModel[col.field] === false) return col;
    return {
      ...col,
      flex: dynamicFlex,
      minWidth: 100,
      maxWidth: undefined,
    };
  });
};
# *Resultados:* 

![Bug_337_1columna](https://github.com/user-attachments/assets/6965d2b6-dc3d-421a-ae61-5c426032bc04)

![Bug_337_4comulnas](https://github.com/user-attachments/assets/980215ca-ca17-4800-b720-d9130dfae404)

