### PR TITLE
#347 Se puede seleccionar una gestion pasada en la etapa 4 y 5

### DIFF
--- a/src/components/stages/ExternalDefenseStage.tsx
+++ b/src/components/stages/ExternalDefenseStage.tsx
@@ -107,6 +107,8 @@ export const ExternalDefenseStage: FC<ExternalDefenseStageProps> = ({ onPrevious
     formik.setFieldValue("date", value);
   };
 
+  const currentDate = dayjs();
+
   return (
     <>
       <div className="txt1">Etapa Final: Defensa Externa</div>
@@ -160,6 +162,8 @@ export const ExternalDefenseStage: FC<ExternalDefenseStageProps> = ({ onPrevious
                   value={formik.values.date}
                   onChange={handleDateChange}
                   format="DD/MM/YYYY"
+                  minDate={currentDate}
+                  maxDate={currentDate.add(1, "year")}
                 />
               </LocalizationProvider>
             </Grid>

--- a/src/components/stages/InternalDefenseStage.tsx
+++ b/src/components/stages/InternalDefenseStage.tsx
@@ -36,6 +36,8 @@ interface InternalDefenseStageProps {
   onNext: () => void;
 }
 
+const currentDate = dayjs();
+
 export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious, onNext }) => {
   const [showModal, setShowModal] = useState<boolean>(false);
   const [editMode, setEditMode] = useState<boolean>(false);
@@ -225,6 +227,8 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
                     value={formik.values.date}
                     onChange={handleDateChange}
                     format="DD/MM/YYYY"
+                    minDate={currentDate}
+                    maxDate={currentDate.add(1, "year")}
                   />
                 </LocalizationProvider>
               </Grid>


### PR DESCRIPTION
# Bug
Los DataPickers tanto de la etapa 4 (Defensa Interna) como de la etapa 5 (Defensa Externa) admiten la introducción de fechas pertenecientes a gestiones pasadas:
![image](https://github.com/user-attachments/assets/aee720a5-65fa-47f9-8879-b1a3c9c2000b)
![image](https://github.com/user-attachments/assets/13e32ede-b849-4c65-ab5a-f645cc9dca3e)

# Fix
Se agregaron fechas mínimas y máximas a los DatePickers de cada etapa, con esto, ya no es posible seleccionar fechas pasadas:
![image](https://github.com/user-attachments/assets/834beccc-13be-478c-a2f3-53ee5c6f2eca)
![image](https://github.com/user-attachments/assets/8a8b0e56-e6d3-4823-9abb-020c110cc9f8)

