### PR TITLE
fix: Limitar ancho de columnas Profesor Page

### DIFF
--- a/src/pages/Professor/ProfessorPage.tsx
+++ b/src/pages/Professor/ProfessorPage.tsx
@@ -262,7 +262,7 @@ const ProfessorPage = () => {
           ...col,
           flex: dynamicFlex,
           minWidth: 100,
-          maxWidth: undefined,
+          maxWidth: 200,
       };
     });
   };


### PR DESCRIPTION
Bug: la tabla de docentes es posible modificar el ancho de las columnas sin ningún límite
![image](https://github.com/user-attachments/assets/df614f14-5b42-489b-9fbb-b27d6f6f16bc)
<img width="812" alt="Screenshot 2025-04-28 at 10 55 15 PM" src="https://github.com/user-attachments/assets/ce0341ab-0e44-41a3-a96b-c22411662703" />
Fix: El problema estaba en la función getResponsiveColumns(), donde al reasignar las columnas se eliminaba el maxWidth original, permitiendo que se expandieran sin límite.
El fix consistió en conservar el maxWidth existente de cada columna para restringir correctamente su ancho máximo.
<img width="801" alt="Screenshot 2025-04-28 at 10 55 53 PM" src="https://github.com/user-attachments/assets/93571d67-300e-40f5-8a4f-b6748f6d776c" />
