### PR TITLE
#404 Edición sin necesidad de presionar un botón al retornar a la Etapa 4

### DIFF
--- a/src/components/stages/InternalDefenseStage.tsx
+++ b/src/components/stages/InternalDefenseStage.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
-import { Box, Grid, Button } from "@mui/material";
+import { Box, Grid, Button, Typography } from "@mui/material";
 
 import { useFormik } from "formik";
 import * as Yup from "yup";
@@ -40,7 +40,7 @@ const currentDate = dayjs();
 
 export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious, onNext }) => {
   const [showModal, setShowModal] = useState<boolean>(false);
-  const [editMode, setEditMode] = useState<boolean>(false);
+  const [readOnly, setReadOnly] = useState<boolean>(true);
 
   const process = useProcessStore((state) => state.process);
   const setProcess = useProcessStore((state) => state.setProcess);
@@ -153,7 +153,7 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
   const isApproveButton = canApproveStage();
 
   const editForm = () => {
-    setEditMode(false);
+    setReadOnly(false);
   };
 
   const nextSubStage = () => {
@@ -161,9 +161,10 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
   };
   return (
     <>
-      <div className="txt1">
-        Etapa 4: Defensa Interna <ModeEditIcon onClick={editForm} />
-      </div>
+      <Typography variant="h6" gutterBottom style={{ fontWeight: "bold" }}>
+        Etapa 4: Defensa Interna{" "}
+        {subStage == 1 && <ModeEditIcon onClick={editForm} style={{ cursor: "pointer" }} />}
+      </Typography>
       {subStage === 0 && (
         <>
           <EmailSender />
@@ -183,7 +184,7 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
             <Grid container spacing={2}>
               <Grid item xs={6} marginTop={5}>
                 <ProfessorAutocomplete
-                  disabled={editMode}
+                  disabled={readOnly}
                   value={String(formik.values.president)}
                   onChange={handlePresidentChange}
                   id="president"
@@ -196,7 +197,7 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
 
               <Grid item xs={6} marginTop={5}>
                 <ProfessorAutocomplete
-                  disabled={editMode}
+                  disabled={readOnly}
                   value={String(formik.values.firstJuror)}
                   onChange={handleFirstJurorChange}
                   id="firstJuror"
@@ -209,7 +210,7 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
 
               <Grid item xs={6} marginTop={5}>
                 <ProfessorAutocomplete
-                  disabled={editMode}
+                  disabled={readOnly}
                   value={String(formik.values.secondJuror)}
                   onChange={handleSecondJurorChange}
                   id="secondJuror"
@@ -223,6 +224,7 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
               <Grid item xs={12} sm={6} marginTop={5}>
                 <LocalizationProvider dateAdapter={AdapterDayjs}>
                   <DatePicker
+                    disabled={readOnly}
                     label="Fecha de Defensa"
                     value={formik.values.date}
                     onChange={handleDateChange}


### PR DESCRIPTION
# Bug
Al acceder a la etapa 4 en el seguimiento de procesos de graduación siempre se permite editar los datos, aún si no se ha activado el modo edición explícitamente:
![image](https://github.com/user-attachments/assets/8b8d9a5e-2d54-4c1e-ad55-d96f775dc577)

# Fix
Se cambia el estado `editMode` por el estado `readOnly`, esto para iniciarlo con un valor `true` al que pueda acceder la propiedad `disabled` sin la necesidad de cambiar el boolean:
```
disabled={readOnly}
```
También se agregó la propiedad al DatePicker para evitar su edición sin solicitud previa.

Se hizo un cambio estético para coincidir con la estética de las otras etapas de graduación, además de garantizar que el botón de edición solo se muestre en la sub-etapa correspondiente:
```
<Typography variant="h6" gutterBottom style={{ fontWeight: "bold" }}>
        Etapa 4: Defensa Interna{" "}
        {subStage == 1 && <ModeEditIcon onClick={editForm} style={{ cursor: "pointer" }} />}
</Typography>
```

![image](https://github.com/user-attachments/assets/4e12fbc2-6580-491a-982b-8bd7d3df5a23)
![image](https://github.com/user-attachments/assets/70ec826f-4fb7-40c0-9f36-8d8c0400d134)
![image](https://github.com/user-attachments/assets/4d0e5665-e70e-497d-857c-0f4707218d1a)
