### PR TITLE
#406 "Tamaño de columna"

### DIFF
--- a/src/pages/graduation/GraduationProcessPage.tsx
+++ b/src/pages/graduation/GraduationProcessPage.tsx
@@ -17,9 +17,9 @@ import ProcessForm from "../CreateGraduation/components/ProcessForm";
 const GraduationProcessPage = () => {
   const [filteredData, setFilteredData] = useState<Student[] | []>([]);
   const [search, setSearch] = useState("");
-  const [open,setOpen] = useState(false);
-  const handleOpen = () => setOpen(true)
-  const handleClose = () => setOpen(false)
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
   const studentsResponse = useLoaderData() as {
     data: Student[];
     message: string;
@@ -59,7 +59,8 @@ const GraduationProcessPage = () => {
       align: "center",
       flex: 1,
       hideable: false,
-      minWidth: 120,
+      minWidth: 150,
+      maxWidth: 250,
     },
     {
       field: "period",
@@ -67,6 +68,8 @@ const GraduationProcessPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      minWidth: 120,
+      maxWidth: 200,
     },
     {
       field: "tutor_name",
@@ -74,6 +77,8 @@ const GraduationProcessPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      minWidth: 150,
+      maxWidth: 250,
     },
     {
       field: "reviewer_name",
@@ -81,6 +86,8 @@ const GraduationProcessPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      minWidth: 150,
+      maxWidth: 250,
     },
     {
       field: "actions",
@@ -90,6 +97,8 @@ const GraduationProcessPage = () => {
       flex: 1,
       filterable: false,
       sortable: false,
+      minWidth: 100,
+      resizable: false,
       renderCell: (params) => (
         <div>
           {
@@ -192,11 +201,7 @@ const GraduationProcessPage = () => {
           />
         </Paper>
       </Box>
-      <ProcessForm
-        isVisible={open}
-        isClosed={handleClose}
-      >
-      </ProcessForm>
+      <ProcessForm isVisible={open} isClosed={handleClose}></ProcessForm>
     </ContainerPage>
   );
 };


### PR DESCRIPTION
# Bug
Al cambiar el tamaño de las columnas en la tabla de procesos de graduación es posible incrementarlas sin límites, dificultando la visualización del resto de datos:
![image](https://github.com/user-attachments/assets/9d8cde5d-78bd-4429-9e6f-49b26d1d1273)

# Fix
Se establecieron tamaños mínimos y máximos para cada cabecera de la tabla con las propiedades `minWidth` y `maxWidth`. También se estableció a la última cabecera como no redimensionable `resizable: false`  para mantener coherencia en el tamaño del extremo derecho de la tabla.

Tamaño mínimo:
![image](https://github.com/user-attachments/assets/1c387d69-24a7-43c5-99dc-1ed9a7724a27)

Tamaño Máximo:
![image](https://github.com/user-attachments/assets/0eaa3193-a237-43d6-9128-ac5d1a88c19a)

>[!Note]
>Hay cambios menores realizados automáticamente por librerías cuando se realizó el commit:
```
const [open, setOpen] = useState(false);
const handleOpen = () => setOpen(true);
const handleClose = () => setOpen(false);
```
```
<ProcessForm isVisible={open} isClosed={handleClose}></ProcessForm>
```