### PR TITLE
#342 Incongruencia de diseño etapa 3

### DIFF
--- a/src/components/stages/ReviewerStage.tsx
+++ b/src/components/stages/ReviewerStage.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
-import { Box, Button, Checkbox, FormControlLabel, Grid } from "@mui/material";
+import { Box, Button, Checkbox, Grid, Paper, Typography } from "@mui/material";
 import ConfirmModal from "../common/ConfirmModal";
 import { steps } from "../../data/steps";
 import { useProcessStore } from "../../store/store";
@@ -139,25 +139,27 @@ export const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) =>
             </LocalizationProvider>
           </Grid>
         </Grid>
-        <Box mt={3}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                name="reviewerDesignationLetterSubmitted"
-                color="primary"
-                checked={formik.values.reviewerDesignationLetterSubmitted}
-                onChange={formik.handleChange}
-                disabled={editMode}
-              />
-            }
-            label="Carta de Designación de Revisor Presentada"
+        <Paper
+          elevation={0}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            backgroundColor: "#e6f4ff",
+            p: 2,
+            borderRadius: 2,
+            mt: 2,
+          }}
+        >
+          <Checkbox
+            name="reviewerDesignationLetterSubmitted"
+            color="primary"
+            checked={formik.values.reviewerDesignationLetterSubmitted}
+            onChange={formik.handleChange}
+            disabled={editMode}
           />
-          {formik.touched.reviewerDesignationLetterSubmitted &&
-          formik.errors.reviewerDesignationLetterSubmitted ? (
-            <div className="text-red-1 text-xs mt-1">
-              {formik.errors.reviewerDesignationLetterSubmitted}
-            </div>
-          ) : null}
+          <Typography variant="body2" sx={{ flexGrow: 1 }}>
+            Carta de Designación de Revisor Presentada
+          </Typography>
           <DownloadButton
             url={REVIEWER_ASSIGNMENT.path}
             data={{
@@ -177,27 +179,34 @@ export const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) =>
               process?.reviewer_fullname || ""
             }.${REVIEWER_ASSIGNMENT.extention}`}
           />
-        </Box>
-
-        <Box mt={3}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                name="reviewerApprovalLetterSubmitted"
-                color="primary"
-                checked={formik.values.reviewerApprovalLetterSubmitted}
-                onChange={formik.handleChange}
-                disabled={editMode}
-              />
-            }
-            label="Carta de Aprobación de Revisor Presentada"
-          />
-          {formik.touched.reviewerApprovalLetterSubmitted &&
-          formik.errors.reviewerApprovalLetterSubmitted ? (
+          {formik.touched.reviewerDesignationLetterSubmitted &&
+          formik.errors.reviewerDesignationLetterSubmitted ? (
             <div className="text-red-1 text-xs mt-1">
-              {formik.errors.reviewerApprovalLetterSubmitted}
+              {formik.errors.reviewerDesignationLetterSubmitted}
             </div>
           ) : null}
+        </Paper>
+        <Paper
+          elevation={0}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            backgroundColor: "#e6f4ff",
+            p: 2,
+            borderRadius: 2,
+            mt: 2,
+          }}
+        >
+          <Checkbox
+            name="reviewerApprovalLetterSubmitted"
+            color="primary"
+            checked={formik.values.reviewerApprovalLetterSubmitted}
+            onChange={formik.handleChange}
+            disabled={editMode}
+          />
+          <Typography variant="body2" sx={{ flexGrow: 1 }}>
+            Carta de Aprobación de Revisor Presentada
+          </Typography>
           <DownloadButton
             url={TUTOR_APPROBAL.path}
             data={{
@@ -213,8 +222,13 @@ export const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) =>
             }}
             filename={`${TUTOR_APPROBAL.filename}_${formik.values.reviewer}.${TUTOR_APPROBAL.extention}`}
           />
-        </Box>
-
+          {formik.touched.reviewerApprovalLetterSubmitted &&
+          formik.errors.reviewerApprovalLetterSubmitted ? (
+            <div className="text-red-1 text-xs mt-1">
+              {formik.errors.reviewerApprovalLetterSubmitted}
+            </div>
+          ) : null}
+        </Paper>
         <Box display="flex" justifyContent="space-between" mt={4}>
           <Button type="button" variant="contained" color="secondary" onClick={onPrevious}>
             Anterior


### PR DESCRIPTION
# Bug
La estética de las secciones 2 y 3 del formulario de procesos de graduación. No es igual, se espera que la estética de la sección 2 se replique en la sección 3.
Etapa 2:
![image](https://github.com/user-attachments/assets/0fb5b683-5e43-4f90-821f-3e8d16f04661)
Etapa 3:
![image](https://github.com/user-attachments/assets/aaa2c3a6-2558-49e0-b56c-fea5287386b3)


# Fix
Se corrigió la estética empleando componentes `Paper` y `Typography` , el resto del código solamente se movió de lugar para incorporarse dentro de estos nuevos componentes.  La estética de ambas secciones ahora es la misma.
```
<Paper
          elevation={0}
          sx={{
            display: "flex",
            alignItems: "center",
            backgroundColor: "#e6f4ff",
            p: 2,
            borderRadius: 2,
            mt: 2,
          }}
        >
        ...
</Paper> 
```

Etapa 2:
![image](https://github.com/user-attachments/assets/3c7edc34-6ae1-4063-9fd5-aedde305e4ea)

Etapa 3:
![image](https://github.com/user-attachments/assets/1e166b4d-37d1-4704-b6e0-2da20f2b6a96)

