### PR TITLE
fix: unifica mensaje de error para número de teléfono en formularios

### DIFF
--- a/src/pages/Professor/CreateProfessorPage.tsx
+++ b/src/pages/Professor/CreateProfessorPage.tsx
@@ -10,6 +10,7 @@ import SuccessDialog from "../../components/common/SucessDialog";
 import LoadingOverlay from "../../components/common/Loading";
 import { COUNTRY_CODES } from "../../constants/countryCodes";
 
+const PHONE_ERROR_MESSAGE = "Ingrese un número de teléfono válido.";
 const onlyLettersRegex = /^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/;
 
 const validationSchema = Yup.object({
@@ -27,7 +28,7 @@ const validationSchema = Yup.object({
     .required("El correo electrónico es obligatorio"),
   countryCode: Yup.string().required("Seleccione un código de país"),
   phoneNumber: Yup.string()
-    .matches(/^\d{7,15}$/, "Número inválido, solo dígitos entre 7 y 15")
+    .matches(/^\d{7,15}$/, PHONE_ERROR_MESSAGE)
     .required("El número de teléfono es obligatorio"),
   degree: Yup.string().required("El título académico es obligatorio"),
   code: Yup.number()

--- a/src/pages/Professor/EditProfessorPage.tsx
+++ b/src/pages/Professor/EditProfessorPage.tsx
@@ -8,6 +8,7 @@ import { useParams } from "react-router-dom";
 import LoadingOverlay from "../../components/common/Loading";
 import { updateProfessor } from "../../services/mentorsService";
 
+const PHONE_ERROR_MESSAGE = "Ingrese un número de teléfono válido.";
 const validationSchema = Yup.object({
   name: Yup.string().required("El nombre completo es obligatorio"),
   lastname: Yup.string().required("El apellido es obligatorio"),
@@ -16,7 +17,7 @@ const validationSchema = Yup.object({
     .email("Ingrese un correo electrónico válido")
     .required("El correo electrónico es obligatorio"),
   phone: Yup.string()
-    .matches(/^[0-9]{8}$/, "Ingrese un número de teléfono válido")
+    .matches(/^[0-9]{8}$/, PHONE_ERROR_MESSAGE)
     .optional(),
   code: Yup.number().optional(),
 });

--- a/src/pages/Student/CreateStudentForm.tsx
+++ b/src/pages/Student/CreateStudentForm.tsx
@@ -19,6 +19,8 @@ import ErrorDialog from "../../components/common/ErrorDialog";
 const lettersRegex = /^[A-Za-zÁÉÍÓÚÑáéíóúñ\s]+$/;
 const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
+const PHONE_ERROR_MESSAGE = "Ingrese un número de teléfono válido.";
+
 const validationSchema = Yup.object({
   name: Yup.string()
     .max(20, "Máximo 20 caracteres")
@@ -40,7 +42,7 @@ const validationSchema = Yup.object({
     .max(50, "Máximo 50 caracteres")
     .required("El correo electrónico es obligatorio"),
 
-  phone: Yup.string().matches(/^\d{8}$/, "El número debe tener exactamente 8 dígitos"),
+  phone: Yup.string().matches(/^\d{8}$/, PHONE_ERROR_MESSAGE),
 
   code: Yup.string().matches(/^\d{1,8}$/, "El código debe tener hasta 8 dígitos"),
 

--- a/src/pages/Student/CreateStudentPage.tsx
+++ b/src/pages/Student/CreateStudentPage.tsx
@@ -21,6 +21,7 @@ import SuccessDialog from "../../components/common/SucessDialog";
 import ErrorDialog from "../../components/common/ErrorDialog";
 import { createIntern } from "../../services/internService";
 
+const PHONE_ERROR_MESSAGE = "Ingrese un número de teléfono válido.";
 const validationSchema = Yup.object({
   name: Yup.string().required("El nombre completo es obligatorio"),
   lastname: Yup.string().required("El apellido es obligatorio"),
@@ -29,7 +30,7 @@ const validationSchema = Yup.object({
     .email("Ingrese un correo electrónico válido")
     .required("El correo electrónico es obligatorio"),
   phone: Yup.string()
-    .matches(/^[0-9]{8}$/, "Ingrese un número de teléfono válido")
+    .matches(/^[0-9]{8}$/, PHONE_ERROR_MESSAGE)
     .optional(),
   code: Yup.string().optional(),
   isIntern: Yup.boolean(),

--- a/src/pages/Student/EditStudentPage.tsx
+++ b/src/pages/Student/EditStudentPage.tsx
@@ -8,6 +8,8 @@ import { useParams } from "react-router-dom";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { IconButton } from "@mui/material";
 
+
+const PHONE_ERROR_MESSAGE = "Ingrese un número de teléfono válido.";
 const validationSchema = Yup.object({
   name: Yup.string().required("El nombre completo es obligatorio"),
   lastname: Yup.string().required("El apellido es obligatorio"),
@@ -16,7 +18,7 @@ const validationSchema = Yup.object({
     .email("Ingrese un correo electrónico válido")
     .required("El correo electrónico es obligatorio"),
   phone: Yup.string()
-    .matches(/^[0-9]{8}$/, "Ingrese un número de teléfono válido")
+    .matches(/^[0-9]{8}$/, PHONE_ERROR_MESSAGE)
     .optional(),
   code: Yup.number().optional(),
 });


### PR DESCRIPTION
bug: Se detectó una inconsistencia en los mensajes de error mostrados cuando se ingresa un número de teléfono inválido en los formularios de crear docente, editar docente y crear nuevo estudiante.
Fix: Se unificó el mensaje de error del campo “número de teléfono” en los 3 formularios, usando una expresión estándar
<img width="511" alt="Screenshot 2025-04-30 at 7 06 25 PM" src="https://github.com/user-attachments/assets/d3c500d1-844f-4fb9-9f69-5f89919184bc" />
<img width="453" alt="Screenshot 2025-04-30 at 7 06 39 PM" src="https://github.com/user-attachments/assets/a658a733-02cf-4231-bf1a-a4a51dbb14ed" />
