### PR TITLE
Bug 352 recuadro azul en buscador de columnas

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mui/material": "^5.16.5",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",
     "@mui/styles": "^5.16.5",
-    "@mui/x-data-grid": "^8.1.0",
+    "@mui/x-data-grid": "^7.3.1",
     "@mui/x-date-pickers": "^7.6.1",
     "@types/xlsx": "^0.0.36",
     "autoprefixer": "^10.4.16",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mui/material": "^5.16.5",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",
     "@mui/styles": "^5.16.5",
-    "@mui/x-data-grid": "^7.3.1",
+    "@mui/x-data-grid": "^8.1.0",
     "@mui/x-date-pickers": "^7.6.1",
     "@types/xlsx": "^0.0.36",
     "autoprefixer": "^10.4.16",

--- a/src/pages/graduation/GraduationProcessPage.tsx
+++ b/src/pages/graduation/GraduationProcessPage.tsx
@@ -141,15 +141,15 @@ const GraduationProcessPage = () => {
                         sx={{
                           '& .MuiOutlinedInput-root': {
                             '&:hover fieldset': {
-                              borderColor: 'secondary.main', // Cambia el color del borde al pasar el ratón
+                              borderColor: 'secondary.main',
                             },
                             '&.Mui-focused fieldset': {
-                              borderColor: 'secondary.main', // Cambia el color del borde cuando el campo está enfocado
+                              borderColor: 'secondary.main',
                             },
                           },
                           '& input': {
-                            outline: 'none !important', // Elimina el contorno
-                            boxShadow: 'none !important', // Elimina la sombra
+                            outline: 'none !important',
+                            boxShadow: 'none !important',
                           },
                         }}
           />

--- a/src/pages/graduation/GraduationProcessPage.tsx
+++ b/src/pages/graduation/GraduationProcessPage.tsx
@@ -138,6 +138,20 @@ const GraduationProcessPage = () => {
             placeholder="Buscar por nombre de estudiante"
             value={search}
             onChange={handleSearchChange}
+                        sx={{
+                          '& .MuiOutlinedInput-root': {
+                            '&:hover fieldset': {
+                              borderColor: 'secondary.main', // Cambia el color del borde al pasar el ratón
+                            },
+                            '&.Mui-focused fieldset': {
+                              borderColor: 'secondary.main', // Cambia el color del borde cuando el campo está enfocado
+                            },
+                          },
+                          '& input': {
+                            outline: 'none !important', // Elimina el contorno
+                            boxShadow: 'none !important', // Elimina la sombra
+                          },
+                        }}
           />
         </div>
       </div>
@@ -189,6 +203,27 @@ const GraduationProcessPage = () => {
               row: "bg-white dark:bg-gray-800",
               columnHeaderTitle: "!font-bold text-center",
             }}
+            slotProps={{
+                columnsManagement: {
+                  autoFocusSearchField: false,
+                  searchInputProps: {
+                    sx: {
+                      "& .MuiOutlinedInput-root": {
+                        "&:hover fieldset": {
+                          borderColor: "secondary.main",
+                        },
+                        "&.Mui-focused fieldset": {
+                          borderColor: "secondary.main",
+                        },
+                      },
+                      "& input": {
+                        outline: "none !important",
+                        boxShadow: "none !important",
+                      },
+                    },
+                  },
+                },
+              }}
           />
         </Paper>
       </Box>


### PR DESCRIPTION
# Bug:
Al acceder a la opción "Administrar Columnas" dentro del módulo de Procesos, el campo de búsqueda de columnas aparece con 2 recuadros azules resaltados sin que el usuario haya interactuado con él.

![Bug_352](https://github.com/user-attachments/assets/37abf0e3-eaf3-4d79-9f95-a3e3b7afb1e1)

# Fix:

Se realizó una modificación en el archivo GraduationProcessPage.tsx para eliminar el borde azul en el campo de búsqueda. Se añadió la configuración de sx en la propiedad searchInputProps, la cual ajusta el borde del campo de búsqueda para evitar el estilo indeseado.

Código modificado:
            sx={{
                          '& .MuiOutlinedInput-root': {
                            '&:hover fieldset': {
                              borderColor: 'secondary.main',
                            },
                            '&.Mui-focused fieldset': {
                              borderColor: 'secondary.main',
                            },
                          },
                          '& input': {
                            outline: 'none !important',
                            boxShadow: 'none !important',
                          },
                        }}

            slotProps={{
                columnsManagement: {
                  autoFocusSearchField: false,
                  searchInputProps: {
                    sx: {
                      "& .MuiOutlinedInput-root": {
                        "&:hover fieldset": {
                          borderColor: "secondary.main",
                        },
                        "&.Mui-focused fieldset": {
                          borderColor: "secondary.main",
                        },
                      },
                      "& input": {
                        outline: "none !important",
                        boxShadow: "none !important",
                      },
                    },
                  },
                },
              }}
# Resultado:
![Bug_352_1](https://github.com/user-attachments/assets/0997a26f-bf45-4e08-8c01-3ae1d1f9753b)
![Bug_352_2](https://github.com/user-attachments/assets/6df10322-e1bb-45c1-a937-290f30bdf3c2)