### PR TITLE
fix: Stage 4 Button goes two stages back

### DIFF
--- a/src/components/stages/InternalDefenseStage.tsx
+++ b/src/components/stages/InternalDefenseStage.tsx
@@ -159,6 +159,14 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
   const nextSubStage = () => {
     setSubStage(subStage + 1);
   };
+
+  const prevSubStage = () => {
+    if(subStage === 0)
+      onPrevious();
+    else
+      setSubStage(subStage - 1);
+  };
+
   return (
     <>
       <div className="txt1">
@@ -168,7 +176,7 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
         <>
           <EmailSender />
           <Box display="flex" justifyContent="space-between" pt={1} pb={0}>
-            <Button type="button" onClick={onPrevious} variant="contained" color="secondary">
+            <Button type="button" onClick={prevSubStage} variant="contained" color="secondary">
               Anterior
             </Button>
             <Button onClick={nextSubStage} variant="contained" color="primary">
@@ -236,7 +244,7 @@ export const InternalDefenseStage: FC<InternalDefenseStageProps> = ({ onPrevious
           </Box>
 
           <Box display="flex" justifyContent="space-between" pt={5}>
-            <Button type="button" onClick={onPrevious} variant="contained" color="secondary">
+            <Button type="button" onClick={prevSubStage} variant="contained" color="secondary">
               Anterior
             </Button>
             <Button type="submit" variant="contained" color="primary">


### PR DESCRIPTION
El boton "Anterior" de la Etapa 4 cuando se seleccion el jurado regresa a la etapa 3 y no asi a la seccion para editar el correo que se envia para la Etapa 4.
![image](https://github.com/user-attachments/assets/37860b2e-ef64-4cf2-8c02-91d255ce52b8)
![image](https://github.com/user-attachments/assets/e72a13e7-c170-4565-8756-e2175874dd6e)
Para arreglar esto, se utilizo el hook subStage ademas de la implementacion de prevSubStage que realiza la verificacion si debe regresar a una etapa anterior, caso contrario resta en 1 el valor de subStage, lo que provoca que de la seleccion regrese al editar y del editar a la etapa anterior. 
![image](https://github.com/user-attachments/assets/b960bf82-d0c4-4b61-ac5f-69165366e313)

