### PR TITLE
#403 El jurado uno y dos pueden ser el mismo en la Etapa 5

### DIFF
--- a/src/components/stages/ExternalDefenseStage.tsx
+++ b/src/components/stages/ExternalDefenseStage.tsx
@@ -43,6 +43,8 @@ export const ExternalDefenseStage: FC<ExternalDefenseStageProps> = ({ onPrevious
   const setProcess = useProcessStore((state) => state.setProcess);
   const defenseDetail = useDefenseExternalDetail(process?.id || 0);
 
+  const [uniqueJurors, setUniqueJurors] = useState<boolean>(true);
+
   const formik = useFormik({
     initialValues: {
       president: defenseDetail?.president?.toString() || "",
@@ -109,6 +111,16 @@ export const ExternalDefenseStage: FC<ExternalDefenseStageProps> = ({ onPrevious
 
   const currentDate = dayjs();
 
+  useEffect(() => {
+    const firstJuror = formik.values.firstJuror;
+    const secondJuror = formik.values.secondJuror;
+    if (firstJuror == "" || secondJuror == "") {
+      setUniqueJurors(true);
+    } else {
+      setUniqueJurors(new Set([firstJuror, secondJuror]).size === 2);
+    }
+  }, [formik.values]);
+
   return (
     <>
       <div className="txt1">Etapa Final: Defensa Externa</div>
@@ -153,6 +165,9 @@ export const ExternalDefenseStage: FC<ExternalDefenseStageProps> = ({ onPrevious
               {formik.touched.secondJuror && formik.errors.secondJuror ? (
                 <div className="text-red-1 text-xs mt-1">{String(formik.errors.secondJuror)}</div>
               ) : null}
+              {!uniqueJurors && (
+                <div className="text-red-1 text-xs mt-1">Los jurados deben ser distintos</div>
+              )}
             </Grid>
 
             <Grid item xs={12} sm={6} marginTop={5}>
@@ -173,7 +188,7 @@ export const ExternalDefenseStage: FC<ExternalDefenseStageProps> = ({ onPrevious
           <Button type="button" onClick={onPrevious} variant="contained" color="secondary">
             Anterior
           </Button>
-          <Button type="submit" variant="contained" color="primary">
+          <Button type="submit" variant="contained" color="primary" disabled={!uniqueJurors}>
             Finalizar
           </Button>
         </Box>


### PR DESCRIPTION
# Bug
Es posible seleccionar al mismo jurado 2 veces en la etapa 5, defensa externa:
![image](https://github.com/user-attachments/assets/4008f24d-190d-48d8-9d7e-d3283ca9eac1)
Se espera un mensaje que indique que ambos jurados deben ser distintos

# Fix
Se agregó una forma de comprobar que ambos jurados sean distintos una vez se introducen los datos en el formulario:
```
const [uniqueJurors, setUniqueJurors] = useState<boolean>(true);

useEffect(() => {
    const firstJuror = formik.values.firstJuror;
    const secondJuror = formik.values.secondJuror;
    if (firstJuror == "" || secondJuror == "") {
      setUniqueJurors(true);
    } else {
      setUniqueJurors(new Set([firstJuror, secondJuror]).size === 2);
    }
  }, [formik.values]);
  
```

Y se muestra un mensaje de error al introducir al mismo jurado 2 veces:
```
{!uniqueJurors && (
      <div className="text-red-1 text-xs mt-1">Los jurados deben ser distintos</div>
 )}
```

Además de evitar que se procese el formulario si no se comprueba que ambos jurados sean distintos:
```
<Button type="submit" variant="contained" color="primary" disabled={!uniqueJurors}>
```


![image](https://github.com/user-attachments/assets/719056ef-c13b-4cf2-886d-8ba5a9a442ab)

>[!Tip]
>Es probable que sea necesario analizar la posibilidad de que el presidente también sea diferente a los jurados.
> Si ese es el caso, un pequeño cambio bastaría para incluir la comprobación:
> `setUniqueJurors(new Set([firstJuror, secondJuror,president]).size === 3);`