### PR TITLE
fix: prevent hiding of 'Código' column in students table

### DIFF
--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -235,7 +235,7 @@ const StudentPage = () => {
             onColumnVisibilityModelChange={(newModel) => {
               const updatedModel = {
                 ...newModel,
-                name: true,
+                code: true, 
               };
               const visibleColumns = Object.values(updatedModel).filter(Boolean).length;
               if (visibleColumns === 0) {


### PR DESCRIPTION
Bug
En la tabla del módulo de estudiantes, era posible ocultar la columna "Código" usando el selector de columnas, lo cual no debería permitirse ya que es un campo obligatorio para identificar al estudiante.
![image](https://github.com/user-attachments/assets/a4a7a76b-dcd4-4889-9169-6045558973be)

FIx
Se ajustó el manejador onColumnVisibilityModelChange para evitar que el usuario oculte la columna "Código", manteniéndola siempre visible.

