### PR TITLE
fix: prevent 'Add Professor' button overlapping title on Professor page

### DIFF
--- a/src/components/common/ContainerPage.tsx
+++ b/src/components/common/ContainerPage.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { Container, Grid, Typography } from "@mui/material";
+import { Container, Stack, Box,  Grid, Typography } from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
 
 interface ContainerPageProps {
@@ -12,35 +12,37 @@ interface ContainerPageProps {
 const ContainerPage: React.FC<ContainerPageProps> = ({ title, subtitle, actions, children }) => {
   return (
     <Container fixed>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <Grid container spacing={3}>
-            <Grid item xs={6}>
-              <Typography
-                variant="h5"
-                component="div"
-                color={"primary"}
-                sx={{ display: "flex", alignItems: "center", gap: 1 }}
-              >
-                <PersonIcon color="primary" />
-                {title}
-              </Typography>
-              <Typography variant="subtitle2" color="textSecondary" component="div">
-                {subtitle}
-              </Typography>
-            </Grid>
-            <Grid item xs={6}>
-              <Typography variant="h6" component="div" sx={{ textAlign: "right" }}>
-                {actions}
-              </Typography>
-            </Grid>
-          </Grid>
-        </Grid>
-        <Grid item xs={12}>
-          {children}
-        </Grid>
+    <Stack
+      direction={{ xs: "column", sm: "row" }}
+      justifyContent="space-between"
+      alignItems={{ xs: "flex-start", sm: "center" }}
+      spacing={2}
+      mb={2}
+    >
+      <Box>
+        <Typography
+          variant="h5"
+          component="div"
+          color={"primary"}
+          sx={{ display: "flex", alignItems: "center", gap: 1 }}
+        >
+          <PersonIcon color="primary" />
+          {title}
+        </Typography>
+        <Typography variant="subtitle2" color="textSecondary" component="div">
+          {subtitle}
+        </Typography>
+      </Box>
+      <Box>
+        {actions}
+      </Box>
+    </Stack>
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        {children}
       </Grid>
-    </Container>
+    </Grid>
+  </Container>
   );
 };
 


### PR DESCRIPTION
Bug
Al hacer zoom o reducir el ancho de la ventana en la pantalla de docentes, el botón “Agregar docente” se sobreponía al texto “Docentes”, causando un problema visual y de usabilidad.
![image](https://github.com/user-attachments/assets/10eec6e1-fc25-4017-84a6-f4dd888309f9)
Fix
Se modificó el layout del componente ContainerPage.tsx, reemplazando la estructura fija de 6 columnas (xs=6) por una distribución más flexible con xs=12 y display: flex, permitiendo que el título y el botón se acomoden correctamente incluso con pantallas reducidas o zoom elevado.
