### PR TITLE
fix: ensure editing a professor doesn't assign student role

### DIFF
--- a/src/pages/Professor/EditProfessorPage.tsx
+++ b/src/pages/Professor/EditProfessorPage.tsx
@@ -32,10 +32,9 @@ const EditProfessorPage = () => {
     try {
       const response = await getUserById(Number(id));
       formik.setValues({
-        ...formik.initialValues,
         ...response,
-        roles: response.roles || [3],
-        role_id: response.role_id || 3,
+        roles: [2], 
+        role_id: 2,
         isStudent: false,
         is_scholarship: false,
         degree: response.degree || "",
@@ -67,8 +66,16 @@ const EditProfessorPage = () => {
     validationSchema,
     onSubmit: async (values) => {
       try {
+        const updatedValues = {
+          ...values,
+          id: Number(id),
+          role_id: 2,
+          roles: [2],
+          isStudent: false,
+          is_scholarship: false
+        };
         // @ts-ignore
-        await updateProfessor(values);
+        await updateProfessor(updatedValues);
         setMessage("Docente actualizado con éxito");
         setSeverity("success");
       } catch (error) {


### PR DESCRIPTION
Bug
Al editar un docente desde el módulo de gestión de docentes, este era convertido en estudiante. Esto ocurría porque en el PUT enviado al backend, no se incluía correctamente la información del rol, y el backend asignaba el rol por defecto o mantenía el anterior.
Así se veía el bug:
Docente apareciendo en la tabla de estudiantes después de editarlo.
Cambios hechos al docente también afectaban al duplicado como estudiante.
![image](https://github.com/user-attachments/assets/eb68648c-5ab9-453e-9478-f2d031cacad3)

Fix
Se solucionó el problema añadiendo los campos role_id: 2, roles: [2] y isStudent: false al enviar el formulario de edición del docente. Esto asegura que el usuario mantenga su rol como docente después de ser editado.