### PR TITLE
Fix:212 Fallo al agregar estudiante sin colocar horas becarias.

### DIFF
--- a/src/pages/Student/CreateStudentForm.tsx
+++ b/src/pages/Student/CreateStudentForm.tsx
@@ -47,10 +47,10 @@ const validationSchema = Yup.object({
   isIntern: Yup.boolean(),
 
   total_hours: Yup.number()
-    .min(0, "Las horas no pueden ser negativas")
-    .when("isIntern", {
+    .min(0, "Las horas no pueden ser negativas.")
+    .when("isIntern",{
       is: true,
-      then: (schema) => schema.required("Las horas becarias son obligatorias"),
+      then: (schema) => schema.required("Las horas becarias son obligatorias."),
       otherwise: (schema) => schema.nullable(),
     }),
 });


### PR DESCRIPTION
Se corrigió el bug que impedía la creación de estudiantes becarios al no validar correctamente las horas asignadas. Ahora el sistema asegura que este campo sea obligatorio solo para becarios, resolviendo el error que bloqueaba el registro.
