### PR TITLE
fix: actualiza visualmente el periodo de inscripción en resumen

### DIFF
--- a/src/components/stages/RegistrationStage.tsx
+++ b/src/components/stages/RegistrationStage.tsx
@@ -70,7 +70,6 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
     if (studentProcess) {
       studentProcess.modality_id = mode;
       studentProcess.period = period;
-      // Actualiza el resumen de inmediato con los datos locales
       setProcess({ ...studentProcess });
       await updateProcess(studentProcess);
       onNext();

--- a/src/components/stages/RegistrationStage.tsx
+++ b/src/components/stages/RegistrationStage.tsx
@@ -70,7 +70,8 @@ export const RegistrationStage: FC<RegistrationStageProps> = ({ onNext }) => {
     if (studentProcess) {
       studentProcess.modality_id = mode;
       studentProcess.period = period;
-      setProcess(studentProcess);
+      // Actualiza el resumen de inmediato con los datos locales
+      setProcess({ ...studentProcess });
       await updateProcess(studentProcess);
       onNext();
     }


### PR DESCRIPTION
Bug: En procesos al cambiar la fecha de inscripción No se actualiza la fecha en el recuadro de resumen de la derecha
<img width="526" alt="Screenshot 2025-05-07 at 9 05 47 AM" src="https://github.com/user-attachments/assets/1e97c163-81e2-4070-98cf-a4f2503522f5" />

Fix: Se actualiza el setProcess con los datos locales justo después del cambio, antes de hacer el await al backend. Esto permite que la UI refleje inmediatamente el periodo seleccionado sin esperar una nueva etapa o refetch.
<img width="476" alt="Screenshot 2025-05-07 at 9 05 59 AM" src="https://github.com/user-attachments/assets/60d6e790-3dba-4dc7-a4db-eaa5ea926eff" />
