### PR TITLE
style: Deshabilitar el botón hasta que ambas cartas estén seleccionada

### DIFF
--- a/src/components/stages/ReviewerStage.tsx
+++ b/src/components/stages/ReviewerStage.tsx
@@ -59,11 +59,11 @@ export const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) =>
 
   const saveStage = async () => {
     if (process) {
-      const { reviewer, reviewerDesignationLetterSubmitted } = formik.values;
+      const { reviewer, reviewerDesignationLetterSubmitted, reviewerApprovalLetterSubmitted } = formik.values;
+      process.reviewer_approval = reviewerApprovalLetterSubmitted;
       process.reviewer_letter = reviewerDesignationLetterSubmitted;
       process.reviewer_id = Number(reviewer);
       process.stage_id = 3;
-      process.reviewer_approval = true;
       process.reviewer_approval_date = dayjs();
       setProcess(process);
       try {
@@ -97,6 +97,7 @@ export const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) =>
     return Boolean(
       formik.values.reviewer &&
         formik.values.reviewerDesignationLetterSubmitted &&
+        formik.values.reviewerApprovalLetterSubmitted &&
         formik.values.date_reviewer_assignament
     );
   };
@@ -219,7 +220,12 @@ export const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) =>
           <Button type="button" variant="contained" color="secondary" onClick={onPrevious}>
             Anterior
           </Button>
-          <Button type="submit" variant="contained" color="primary">
+          <Button type="submit" variant="contained" color="primary"
+          disabled={
+              !formik.values.reviewerDesignationLetterSubmitted ||
+              !formik.values.reviewerApprovalLetterSubmitted
+            }
+          >
             {isApproveButton ? "Aprobar Etapa" : "Guardar"}
           </Button>
         </Box>


### PR DESCRIPTION
# Bug : 
 En la etapa 3(Defensa interna), notar que se puede elegir una opción entre las "Carta de Designación de Revisor Presentada", "Carta de Aprobación de Revisor Presentada" y pasar a la siguiente etapa lo cual no debería pasar ya que si o si debería ser necesario marcar las 2 opciones antes de pasar a la siguiente etapa.

![BUG_448_1](https://github.com/user-attachments/assets/64ecdb52-832e-442b-9028-0c4e9d41cfba)


# Fix: 
Se realizó una modificación en el archivo ReviewerStage.tsx para habilitar el botón de "Guardar" solo cuando ambas cartas estén seleccionadas. Se añadió la lógica en el botón para deshabilitarlo si las cartas no están marcadas. También se cambió el comportamiento para que el mensaje de "Guardar" solo aparezca cuando las condiciones sean correctas.
Código modificado:

<Button
  type="submit"
  variant="contained"
  color="primary"
  disabled={
    !formik.values.reviewerDesignationLetterSubmitted ||
    !formik.values.reviewerApprovalLetterSubmitted
  }
>
  {isApproveButton ? "Aprobar Etapa" : "Guardar"}
</Button>
# Resultado : 

![BUG_448_4](https://github.com/user-attachments/assets/ec55f246-9ed9-4f17-9bde-e6365c34690c)
![BUG_448_3](https://github.com/user-attachments/assets/20b61a64-823e-42c8-9038-22b38b04332b)
![BUG_448_2](https://github.com/user-attachments/assets/8b20103f-84f3-4fab-ac4b-1e0f8b77cd6e)
