### PR TITLE
#520 Feat: Migración del Helper de Permisos para usar Datos de Zustand

### DIFF
--- a/src/helper/permissions.ts
+++ b/src/helper/permissions.ts
@@ -1,18 +1,7 @@
-import { Permission } from '../models/permissionInterface';
-import { useUserStore } from '../store/store';
+import { useUserDataStore } from '../store/store';
 
 export function HasPermission(permissionName: string): boolean {
-  const user = useUserStore((state) => state.user);
-  let hasThePermission = false;
-  if (user) {
-    Object.keys(user.roles_permissions).forEach((role_number: string) => {
-      const rolePermissions = user.roles_permissions[role_number];
-      rolePermissions?.permissions.forEach((permission: Permission) => {
-        if (permissionName.toLowerCase() === permission.name.toLowerCase()) {
-          hasThePermission = true;
-        }
-      });
-    });
-  }
-  return hasThePermission;
+  const permission = permissionName.toLowerCase();
+  const userPermissions = useUserDataStore((state) => state.permissions);
+  return userPermissions.length > 0 && userPermissions.includes(permission);
 }


### PR DESCRIPTION
# Cambio en `permission.ts`
Se reemplazó el uso de la antigua store desde la que se extraían los permisos en base a los roles del usuario, en cambio se emplea la estructura nueva que simplifica la lectura de permisos al tenerlos todos en una lista propia.

La lógica implementada es simple, luego de duplicar el parámetro de entrada y convertirlo en letras minúsculas para evitar errores, se compueba que el usuario posea por lo menos un permiso para empezar la búsqueda del permiso solicitado en toda la estructura de permisos, si el permiso solicitado se encuentra dentro de la lista, se devuelve `true`, caso contrario, se devuelve `false`.

# Tests
Para probar el correcto funcionamiento de la lógica, se cargaron permisos en el login y se guardaron con la store:
![image](https://github.com/user-attachments/assets/6b03f310-d282-4079-815b-27195bebeaa0)
Y se edito (solo para la prueba) la solicitud de permisos en la página de estudiantes, específicamente para las acciones de edición y borrado de datos. Los resultados se muestran a continuación:

* Usuario posee ambos permisos:
![image](https://github.com/user-attachments/assets/2a30a5c0-dbc5-49a0-a8d5-1daa5777fc04)
![image](https://github.com/user-attachments/assets/5d4e250c-7bc2-44e8-a988-3bcf71935ee5)
* Usuario no posee uno de los permisos:
![image](https://github.com/user-attachments/assets/e9d7413d-ca5e-42e2-bb0a-d52887912df5)
![image](https://github.com/user-attachments/assets/e5e15d07-2c96-49b4-92d4-b171b1b4f602)
* Usuario no posee ninguno de los permisos:
![image](https://github.com/user-attachments/assets/f8cd1fd9-8a9d-40c8-a980-f19a481497e4)
![image](https://github.com/user-attachments/assets/14557385-424a-42f8-a7b2-313283be9db7)
