### PR TITLE
Fix: Incorrect modality pdf

### DIFF
--- a/src/components/stages/DocumentCheckbox.tsx
+++ b/src/components/stages/DocumentCheckbox.tsx
@@ -105,9 +105,9 @@ const DocumentCheckbox: FC<DocumentCheckboxProps> = ({ disabled, formik, carrer,
             ano: dayjs().format("YYYY"),
             title_project: process?.project_name || "",
             date: dayjs(formik.values.date_tutor_assignament).format("DD/MM/YYYY"),
-            isTesis: process?.modality_id === 3 ? "  X" : "",
-            isProject: process?.modality_id === 1 ? "  X" : "",
-            isJob: process?.modality_id === 2 ? "  X" : "",
+            isTesis: process?.modality_id.toString() === "3" ? "  X" : "",
+            isProject: process?.modality_id.toString() === "1" ? "  X" : "",
+            isJob: process?.modality_id.toString() === "2" ? "  X" : "",
           }}
           filename={`${TUTOR_APPROBAL.filename}_${formik.values.mentorName}.${TUTOR_APPROBAL.extention}`}
         />


### PR DESCRIPTION
Cuando se selecciona la opcion para descargar "Carta de Aprobación de Tutor Presentada" no se seleccionaba de forma correcta en el pdf.
![image](https://github.com/user-attachments/assets/e00b4269-a624-4a02-b41e-11c89663c476)

Ademas de agregar valores en data para que se pueda utilizar en el pdf y transformarlo en datos compatibles con la respuesta de backend
![image](https://github.com/user-attachments/assets/7e7effc0-2a97-4df8-837c-7684fa3ebd92)
