### PR TITLE
fix: validación y actualización correcta de fecha de asignación en et…

### DIFF
--- a/src/components/stages/ReviewerStage.tsx
+++ b/src/components/stages/ReviewerStage.tsx
@@ -22,7 +22,11 @@ const validationSchema = Yup.object({
   reviewer: Yup.string().required("* El revisor es obligatorio"),
   reviewerDesignationLetterSubmitted: Yup.boolean(),
   reviewerApprovalLetterSubmitted: Yup.boolean(),
-  date_reviewer_assignament: Yup.mixed().required("Debe seleccionar una fecha"),
+  date_reviewer_assignament: Yup.date()
+  .typeError("Debe seleccionar una fecha válida")
+  .max(new Date(), "La fecha no puede ser futura")
+  .min(dayjs().subtract(6, "month").toDate(), "La fecha es demasiado antigua")
+  .required("Debe seleccionar una fecha"),
 });
 
 interface ReviewerStageProps {


### PR DESCRIPTION
Bug
Al editar la fecha de asignación del tutor o revisor, el sistema no actualizaba correctamente el valor. Incluso si el usuario cambiaba la fecha, al guardar la etapa el cambio no se persistía.
Esto ocurría porque el campo del formulario se mostraba visualmente, pero no se validaba correctamente ni se sincronizaba con el estado del proceso.

Fix
Se aplicó una validación en el campo de fecha, tanto visual (en rojo si no es válida) como funcional (para evitar fechas antiguas). Además, se corrigió el handleDateChange para que actualice correctamente el valor en formik.