### PR TITLE
fix: disable download buttons until reviewer is selected

### DIFF
--- a/src/components/ProgressTracker.tsx
+++ b/src/components/ProgressTracker.tsx
@@ -3,7 +3,7 @@ import { Stepper, Step, StepLabel, Box, Typography, Snackbar, Alert } from "@mui
 import InternalDefenseStage from "./stages/InternalDefenseStage";
 import { MentorStage } from "./stages/MentorStage";
 import { RegistrationStage } from "./stages/RegistrationStage";
-import { ReviewerStage } from "./stages/ReviewerStage";
+import ReviewerStage from "./stages/ReviewerStage";
 import ExternalDefenseStage from "./stages/ExternalDefenseStage";
 import { Seminar } from "../models/studentProcess";
 import { steps } from "../data/steps";

--- a/src/pages/graduation/ProcessInfoPage.tsx
+++ b/src/pages/graduation/ProcessInfoPage.tsx
@@ -1,10 +1,10 @@
 import { useLoaderData } from "react-router-dom";
+import { useEffect } from "react";
+import { Grid } from "@mui/material";
 import Checklist from "../../components/Checklist";
 import ProgressTracker from "../../components/ProgressTracker";
 import { Seminar } from "../../models/studentProcess";
 import { useProcessStore } from "../../store/store";
-import { Grid } from "@mui/material";
-import { useEffect } from "react";
 import { steps } from "../../data/steps";
 
 const ProcessInfoPage = () => {
@@ -17,7 +17,7 @@ const ProcessInfoPage = () => {
     updateProcess(data);
   }, [data, updateProcess]);
 
-  const stageProcess = data.stage_id;
+  const stageProcess = data.stage_id || 0;
 
   return (
     <Grid container spacing={2}>


### PR DESCRIPTION
## 🛠️ Fix: Botones de descarga deshabilitados hasta seleccionar revisor

### Descripción
Se ha corregido un problema de usabilidad donde los botones de descarga aparecían habilitados incluso si no se había seleccionado un revisor, lo cual podía generar errores o confusión en el proceso.

### Cambios realizados
- Se deshabilitan los botones de descarga si no se ha seleccionado un revisor.
- Se añadió `Tooltip` para indicar que es necesario seleccionar un revisor para habilitar la descarga.
- Se ajustó la lógica de validación para mejorar la experiencia de usuario.
- Se corrigieron algunos errores menores de ESLint.

---

✅ Listo para revisión.
