### PR TITLE
fix(UPB-90): role filter compares role names and returns correctly

### DIFF
--- a/src/models/userInterface.ts
+++ b/src/models/userInterface.ts
@@ -11,7 +11,7 @@ export interface User {
   code: string;
   phone: string;
   degree: string;
-  roles: number[];
+  roles: string[];
   rolesAndPermissions?: { [id: number]: Role };
 }
 

--- a/src/pages/Users/UsersPage.tsx
+++ b/src/pages/Users/UsersPage.tsx
@@ -139,10 +139,10 @@ const UsersPage = () => {
       });
     }
 
-    if (filterRoles) {
-      filteredData = filteredData.filter((user: User) => {
-        return user.roles.includes(Number(filterRoles));
-      });
+    if (filterRoles) { 
+      filteredData = filteredData.filter((user: User) => 
+        user.roles?.includes(filterRoles) 
+      ); 
     }
 
     setFilteredUsers(filteredData);
@@ -264,9 +264,8 @@ const UsersPage = () => {
     fetchRoles();
   }, []);
 
-  const countStudentsWithRole = (role: string) => {
-    return users.filter((user) => user.roles.includes(Number(role))).length;
-  };
+  const countStudentsWithRole = (role: string) =>
+    users.filter((user) => user.roles?.includes(role)).length;
 
   return (
     <ContainerPage


### PR DESCRIPTION
### Archivos modificados
- `src/models/userInterface.ts`  
- `src/pages/Users/UsersPage.tsx`

### Cambios realizados
- `src/models/userInterface.ts`  
  - **`roles: number[] → roles: string[]`** 

- `src/pages/Users/UsersPage.tsx`  
  - **Filtro por rol**: se reemplaza `includes(Number(filterRoles))` por `includes(filterRoles)` (comparación **string vs string**).  
  - **Predicado de `filter`**: ahora **retorna** el booleano (`user.roles?.includes(filterRoles)`), corrigiendo el callback sin `return`.  
  - **Contador en el menú**: `countStudentsWithRole` ahora **retorna** el `length`, corrigiendo el tipo inferido por TS de `void`.  

---

## Pasos de prueba manual
1. Iniciar backend (`npm run dev`) y frontend (`npm run dev`).  
2. Login con `admin@upb.edu` / `123456`.  
3. Navegar a **Usuarios**.  
4. En el filtro **Rol**, seleccionar `student` (o `professor`/`admin`).  
5. Verificar que solo aparecen usuarios con ese rol.  
6. Escribir un texto en el buscador y confirmar que la búsqueda + filtro funcionan combinados.  
7. Click en **“Borrar búsqueda”** → se restablecen filtro y texto y se muestran todos.

---

## Impacto
- El **listado** ahora tipa `User.roles` como **`string[]`** porque el adaptador ya asignaba **nombres** .  
- **Crear/Editar usuario** no se ve afectado: allí se manejan **IDs numéricos** en el payload (otra forma/DTO).  
- No se introducen dependencias nuevas, solo corrección de tipos y comparaciones.
