### PR TITLE
Feat/Add GitHub Action to notify Discord on PR opened

### DIFF
--- a/.github/workflows/notify_discord.yml
+++ b/.github/workflows/notify_discord.yml
@@ -1,0 +1,25 @@
+name: Notificar PR en Discord
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Enviar información del PR a Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d '{
+                 "content": "Nuevo Pull Request\n\nRepositorio: isc-system-core\n\nPR ID: #${{ github.event.pull_request.number }}\n\nTítulo: ${{ github.event.pull_request.title }}\n\nURL: ${{ github.event.pull_request.html_url }}\n\nBranch origen: ${{ github.event.pull_request.head.ref }}\n\nBranch destino: ${{ github.event.pull_request.base.ref }}\n\nCambios: Ver Cambios\n\nRevisa la sección de Pull Requests del repositorio."
+               }' \
+               "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
Title: Refactor notify-discord.yml para usar secret de GitHub Actions

Descripción:
Se actualiza el workflow de notificación a Discord para leer la URL del webhook desde un secret en lugar de exponerla en el repositorio.

Cambios:
- Solo se modificó .github/workflows/notify-discord.yml

Cómo añadir el webhook de Discord como secret:
1. En el repositorio, ir a Settings → Secrets and variables → Actions
2. Hacer clic en New repository secret
3. Rellenar Name: DISCORD_WEBHOOK_URL
4. Rellenar Value: https://discordapp.com/api/webhooks/<WEBHOOK_DEL_CANAL_A_TESTEAR>
5. Guardar

Validación:
1. Abrir un nuevo pull request contra este branch
2. Verificar que el workflow se ejecute y llegue la notificación al canal de Discord configurado
