### PR TITLE
Feat/AddGithubWebhookWIthSecret

### DIFF
--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -1,0 +1,25 @@
+name: Notificar PR en Discord
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Enviar información del PR a Discord
+        shell: bash
+        env:
+          WEBHOOK_LINK: ${{ secrets.webhook_link }}
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d '{
+                 "content":"🚀 Nuevo Pull Request 🚀\n\n📜 Repositorio: isc-system-core\n\n📝 PR ID: #${{ github.event.pull_request.number }}\n\n📢 Título del PR: ${{ github.event.pull_request.title }}\n\n🔗 URL del PR: ${{ github.event.pull_request.html_url }}\n\n🔀 Branch origin: ${{ github.event.pull_request.head.ref }}\n\n🔀 Branch destiny: ${{ github.event.pull_request.base.ref }}\n\n🔍 Cambios: Ver Cambios\n\n¡Revisa la sección de Pull Requests del repositorio!"
+               }' \
+               "$WEBHOOK_LINK"


### PR DESCRIPTION
# Descripción
Implementa notificaciones de Pull Requests en el canal repos-frontend de Discord para el frontend de isc-system-web.

## Cambios

### Añadidos
- .github/workflows/notify-pr-discord.yml: workflow que envía notificaciones de PR al canal repos-backend  
- Estrategia matrix: runners ubuntu-latest y windows-latest  
- Uso del secret WEBHOOK_LINK como variable de entorno

### Eliminados
- URL del webhook codificada directamente en el YAML   



## Documentación
- Consulta `webhook.pdf` para ver el procedimiento paso a paso y vincular el secret al canal de Discord correspondiente.

<img width="666" height="469" alt="Captura desde 2025-10-14 15-02-29" src="https://github.com/user-attachments/assets/58e2bf16-bd69-4612-b105-6fa75b88b1ff" />