### PR TITLE
fix(UPB-204): limit assignment date using dynamic range (ENV) + Yup nullable validation

### DIFF
--- a/src/components/stages/ReviewerStage.tsx
+++ b/src/components/stages/ReviewerStage.tsx
@@ -30,6 +30,18 @@ import DownloadButton from "../common/DownloadButton";
 import letters from "../../constants/letters";
 import { useCarrerStore } from "../../store/carrerStore";
 
+const parseEnvNumber = (v: unknown, d: number) => {
+  const n = Number(v as any);
+  return Number.isFinite(n) ? n : d;
+};
+
+const PAST_MONTHS = parseEnvNumber(import.meta?.env?.VITE_STAGE3_DATE_PAST_MONTHS, 12);
+const FUTURE_MONTHS = parseEnvNumber(import.meta?.env?.VITE_STAGE3_DATE_FUTURE_MONTHS, 6);
+
+const NOW = dayjs();
+const MIN_DATE = NOW.subtract(PAST_MONTHS, "month");
+const MAX_DATE = NOW.add(FUTURE_MONTHS, "month");
+
 const { TUTOR_APPROBAL, REVIEWER_ASSIGNMENT } = letters;
 
 const validationSchema = Yup.object({
@@ -40,13 +52,29 @@ const validationSchema = Yup.object({
       "* El revisor no puede ser el mismo docente que el tutor",
       function (value) {
         const { parent } = this;
-        const { tutorId } = parent;
+        const { tutorId } = parent as { tutorId?: number | string };
         return !value || !tutorId || value !== tutorId.toString();
+      }
+    ),
+  date_reviewer_assignament: Yup.mixed<Dayjs>()
+    .nullable()
+    .required("* La fecha de asignación es obligatoria")
+    .test(
+      "min-range",
+      () => `* La fecha no puede ser anterior a ${MIN_DATE.format("DD/MM/YYYY")}`,
+      (value) => {
+        return !!value && (value.isSame(MIN_DATE, "day") || value.isAfter(MIN_DATE));
+      }
+    )
+    .test(
+      "max-range",
+      () => `* La fecha no puede ser posterior a ${MAX_DATE.format("DD/MM/YYYY")}`,
+      (value) => {
+        return !!value && (value.isSame(MAX_DATE, "day") || value.isBefore(MAX_DATE));
       }
     ),
   reviewerDesignationLetterSubmitted: Yup.boolean(),
   reviewerApprovalLetterSubmitted: Yup.boolean(),
-  date_reviewer_assignament: Yup.mixed().required("Debe seleccionar una fecha"),
 });
 
 interface ReviewerStageProps {
@@ -80,8 +108,9 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
 
   const [editMode, setEditMode] = useState<boolean>(isReadOnlyMode());
 
-  const wasReviewerApproved = () =>
-    Boolean(process?.reviewer_approval && process?.stage_id > CURRENT_STAGE);
+  const wasReviewerApproved = () => {
+    return Boolean(process?.reviewer_approval && process?.stage_id > CURRENT_STAGE);
+  };
 
   const [currentReviewerId, setCurrentReviewerId] = useState<string>(
     process?.reviewer_id?.toString() || ""
@@ -90,7 +119,7 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
   const isDuplicateSelection = (reviewerId?: string) => {
     const tutorId = process?.tutor_id;
     const selectedReviewer = reviewerId || currentReviewerId;
-    return tutorId && selectedReviewer && tutorId.toString() === selectedReviewer;
+    return !!tutorId && !!selectedReviewer && tutorId.toString() === selectedReviewer;
   };
 
   const formik = useFormik({
@@ -141,15 +170,15 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
     }
   }, [process]);
 
-  const canApproveStage = () =>
-    Boolean(
+  const canApproveStage = () => {
+    return Boolean(
       formik.values.reviewer &&
         formik.values.reviewerDesignationLetterSubmitted &&
         formik.values.reviewerApprovalLetterSubmitted &&
         formik.values.date_reviewer_assignament &&
         !isDuplicateSelection(formik.values.reviewer)
     );
-
+  };
   const isApproveButton = canApproveStage();
   const hasReviewer = Boolean(formik.values.reviewer);
 
@@ -166,8 +195,8 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
     const { reviewer, reviewerDesignationLetterSubmitted, reviewerApprovalLetterSubmitted } =
       formik.values;
 
-    const currentReviewerId = Number(reviewer);
-    const reviewerChanged = originalReviewerId !== currentReviewerId;
+    const currentReviewerIdNumber = Number(reviewer);
+    const reviewerChanged = originalReviewerId !== currentReviewerIdNumber;
     const wasApproved = process.reviewer_approval;
     const shouldAdvanceToNextStage = isApproveButton && !reviewerChanged;
 
@@ -187,7 +216,7 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
     }
 
     updatedProcess.reviewer_letter = reviewerDesignationLetterSubmitted;
-    updatedProcess.reviewer_id = currentReviewerId;
+    updatedProcess.reviewer_id = currentReviewerIdNumber;
     updatedProcess.date_reviewer_assignament = formik.values.date_reviewer_assignament;
 
     if (shouldAdvanceToNextStage) {
@@ -327,6 +356,8 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
                 value={formik.values.date_reviewer_assignament}
                 onChange={handleDateChange}
                 format="DD/MM/YYYY"
+                minDate={MIN_DATE}
+                maxDate={MAX_DATE}
               />
             </LocalizationProvider>
           </Grid>
@@ -373,9 +404,7 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
                   month: dayjs().format("MMMM"),
                   year: dayjs().format("YYYY"),
                 }}
-                filename={`${REVIEWER_ASSIGNMENT.filename}_${
-                  process?.reviewer_fullname || ""
-                }.${REVIEWER_ASSIGNMENT.extention}`}
+                filename={`${REVIEWER_ASSIGNMENT.filename}_${process?.reviewer_fullname || ""}.${REVIEWER_ASSIGNMENT.extention}`}
               />
             </span>
           </Tooltip>


### PR DESCRIPTION
# fix(graduation-stage3): Limitar rango de fecha en Etapa 3 (Fecha de Asignación)

Como desarrollador frontend quiero que el selector de **Fecha de Asignación** de la **Etapa 3 (Seleccionar Revisor)** limite la selección a un rango de fechas válido para evitar fechas incoherentes (p. ej., 1900 o 2099), de modo que el usuario solo pueda escoger fechas razonables según el periodo académico definido.

## Criterios de aceptación 
### Cuando se edita o crea la Etapa 3:
- [x] La **Fecha de Asignación** tiene un **valor mínimo y máximo** visible en el `DatePicker` (no permite navegar/seleccionar fuera del rango).
- [x] El rango **no** está hardcodeado en años absolutos; se calcula dinámicamente a partir de **hoy** usando un **rango configurable** en meses (pasado y futuro).
- [x] Si el usuario intenta forzar una fecha fuera de rango, la **validación** del formulario lo bloquea y muestra un **mensaje de error**.

### Configuración (rango dinámico)
- `VITE_STAGE3_DATE_PAST_MONTHS` → meses hacia el **pasado** (default: `12`).
- `VITE_STAGE3_DATE_FUTURE_MONTHS` → meses hacia el **futuro** (default: `6`).

> Nota: El PO puede ajustar el rango (ej. 2 semestres pasados y 1 a futuro) sin tocar código, modificando estas variables de entorno del **frontend**.

## Archivos modificados
- `src/components/stages/ReviewerStage.tsx`

## Cambios realizados
- Se añade **rango dinámico** para la fecha:
  - Cálculo de `MIN_DATE` y `MAX_DATE` en base a `dayjs()` y los ENV `VITE_STAGE3_DATE_PAST_MONTHS`/`VITE_STAGE3_DATE_FUTURE_MONTHS`.
  - Propiedades `minDate={MIN_DATE}` y `maxDate={MAX_DATE}` en el componente `DatePicker`.
- Se corrige validación Yup para permitir `null` y validar rango:
  - `Yup.mixed<Dayjs>().nullable().required(...)`
  - Tests de rango `min-range` y `max-range` con mensajes explícitos.
- **No** se modifican endpoints ni contratos con backend. **No** se crean archivos nuevos.

## Pasos para reproducir el bug (antes del fix)
1. Iniciar sesión como admin de procesos (Email: `alexismarechal@upb.edu`, Password: `123456`).
2. Ir a **Procesos de Graduación** → **Visualizar** un proceso con Etapa 3.
3. Editar Etapa 3 → abrir el selector de **Fecha de Asignación**.
4. Intentar seleccionar una fecha incoherente (ej. `17/04/2078`).  
**Esperado (bug):** el selector lo permitía.

## QA (después del fix)
1. Configurar, si se desea, el rango vía ENV en el frontend (opcional):
   ```env
   VITE_STAGE3_DATE_PAST_MONTHS=12
   VITE_STAGE3_DATE_FUTURE_MONTHS=6
   ```
2. Iniciar sesión como admin de procesos y entrar a Etapa 3.
3. Abrir el `DatePicker` de **Fecha de Asignación**.
4. Verificar que **no** se puede navegar/seleccionar fuera del rango (meses deshabilitados).
5. Intentar forzar una fecha inválida: el formulario muestra error y **no** guarda.
6. Seleccionar una fecha válida dentro del rango y **guardar/aprobar** con normalidad.

## Evidencia
- Demo manual en UI (sin Postman, al ser cambio **frontend**).  
- Capturas:
<img width="972" height="675" alt="{E95F03F8-10E1-480B-A7FC-8A6B11CAB2D9}" src="https://github.com/user-attachments/assets/7ead231e-3cc5-44d2-b766-a8d8ffdd2034" />
> **Se muestra el rango de años.** 
<img width="948" height="659" alt="{0986BE2B-6A03-4F5A-A3C3-209C5A15A3B8}" src="https://github.com/user-attachments/assets/92ba2109-4233-4436-884b-f75976b4e0a7" />
> **Se muestra el rango de meses para adelante a partir de hoy.**

---

## Consideraciones
- El rango es **configurable** y no depende de datos de backend.  
- Si existen procesos antiguos con fechas históricas fuera del rango, al editar se solicitará corregir la fecha antes de guardar (comportamiento esperado).
