### PR TITLE
fix(graduation): responsive layout in ReviewerStage (cards without overlap and Download button without overflow)

### DIFF
--- a/src/components/stages/DocumentCheckbox.tsx
+++ b/src/components/stages/DocumentCheckbox.tsx
@@ -7,6 +7,7 @@ import letters from "../../constants/letters";
 import { Seminar } from "../../models/studentProcess";
 import { MentorFormValues } from "../../hooks/useMentorFormik";
 import { Carrer } from "../../store/carrerStore";
+import { Box } from "@mui/material";
 
 const { TUTOR_APPROBAL, TUTOR_ASSIGNMENT } = letters;
 
@@ -36,7 +37,10 @@ const DocumentCheckbox: FC<DocumentCheckboxProps> = ({ disabled, formik, carrer,
         elevation={0}
         sx={{
           display: "flex",
-          alignItems: "center",
+          flexWrap: "wrap",
+          flexDirection: { xs: "column", sm: "row" },
+          alignItems: { xs: "stretch", sm: "center" },
+          gap: 1.5,
           backgroundColor: "#e6f4ff",
           p: 2,
           borderRadius: 2,
@@ -73,7 +77,10 @@ const DocumentCheckbox: FC<DocumentCheckboxProps> = ({ disabled, formik, carrer,
         elevation={0}
         sx={{
           display: "flex",
-          alignItems: "center",
+          flexWrap: "wrap",
+          flexDirection: { xs: "column", sm: "row" },
+          alignItems: { xs: "stretch", sm: "center" },
+          gap: 1.5,
           backgroundColor: "#e6f4ff",
           p: 2,
           borderRadius: 2,
@@ -90,27 +97,41 @@ const DocumentCheckbox: FC<DocumentCheckboxProps> = ({ disabled, formik, carrer,
         <Typography variant="body2" sx={{ flexGrow: 1 }}>
           {"Carta de Aprobación de Tutor Presentada"}
         </Typography>
-        <DownloadButton
-          url={TUTOR_APPROBAL.path}
-          disabled={!isMentorSelected}
-          onClick={handleBlockedDownload}
-          data={{
-            student: process?.student_fullname || "",
-            tutor: process?.tutor_fullname || "",
-            jefe_carrera: carrer?.headOfDepartment || "",
-            degree: process?.tutor_degree || "",
-            carrera: carrer?.fullName || "",
-            dia: dayjs().format("DD"),
-            mes: dayjs().format("MMMM"),
-            ano: dayjs().format("YYYY"),
-            title_project: process?.project_name || "",
-            date: dayjs(formik.values.date_tutor_assignament).format("DD/MM/YYYY"),
-            isTesis: process?.modality_id.toString() === "3" ? "  X" : "",
-            isProject: process?.modality_id.toString() === "1" ? "  X" : "",
-            isJob: process?.modality_id.toString() === "2" ? "  X" : "",
+        <Box
+          sx={{
+            minWidth: 0,
+            width: { xs: "100%", sm: "auto" },
+            "& .MuiButton-root": {
+              maxWidth: { xs: "100%", sm: 260 },
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              px: 1.5,
+            },
           }}
-          filename={`${TUTOR_APPROBAL.filename}_${formik.values.mentorName}.${TUTOR_APPROBAL.extention}`}
-        />
+        >
+          <DownloadButton
+            url={TUTOR_APPROBAL.path}
+            disabled={!isMentorSelected}
+            onClick={handleBlockedDownload}
+            data={{
+              student: process?.student_fullname || "",
+              tutor: process?.tutor_fullname || "",
+              jefe_carrera: carrer?.headOfDepartment || "",
+              degree: process?.tutor_degree || "",
+              carrera: carrer?.fullName || "",
+              dia: dayjs().format("DD"),
+              mes: dayjs().format("MMMM"),
+              ano: dayjs().format("YYYY"),
+              title_project: process?.project_name || "",
+              date: dayjs(formik.values.date_tutor_assignament).format("DD/MM/YYYY"),
+              isTesis: process?.modality_id.toString() === "3" ? "  X" : "",
+              isProject: process?.modality_id.toString() === "1" ? "  X" : "",
+              isJob: process?.modality_id.toString() === "2" ? "  X" : "",
+            }}
+            filename={`${TUTOR_APPROBAL.filename}_${formik.values.mentorName}.${TUTOR_APPROBAL.extention}`}
+          />
+        </Box>
       </Paper>
     </>
   );

--- a/src/components/stages/ReviewerStage.tsx
+++ b/src/components/stages/ReviewerStage.tsx
@@ -311,7 +311,7 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
 
       <form onSubmit={formik.handleSubmit} className="mt-5 mx-16">
         <Grid container spacing={3}>
-          <Grid item xs={6}>
+          <Grid item xs={12} md={6}>
             <ProfessorAutocomplete
               disabled={editMode}
               value={formik.values.reviewer}
@@ -323,7 +323,7 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
               <div className="text-red-1 text-xs mt-1">{formik.errors.reviewer}</div>
             ) : null}
           </Grid>
-          <Grid item xs={6}>
+          <Grid item xs={12} md={6}>
             <LocalizationProvider dateAdapter={AdapterDayjs}>
               <DatePicker
                 disabled={editMode}
@@ -342,7 +342,10 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
           elevation={0}
           sx={{
             display: "flex",
-            alignItems: "center",
+            flexWrap: "wrap",
+            flexDirection: { xs: "column", sm: "row" },
+            alignItems: { xs: "stretch", sm: "center" },
+            gap: 1.5,
             backgroundColor: "#e6f4ff",
             p: 2,
             borderRadius: 2,
@@ -359,10 +362,20 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
           <Typography variant="body2" sx={{ flexGrow: 1 }}>
             {"Carta de Designación de Revisor Presentada\r"}
           </Typography>
-          <Tooltip
-            title={!hasReviewer ? "Debe seleccionar un revisor para habilitar esta descarga" : ""}
-          >
-            <span>
+          <Tooltip title={!hasReviewer ? "Debe seleccionar un revisor para habilitar esta descarga" : ""}>
+            <Box
+              sx={{
+                minWidth: 0,
+                width: { xs: "100%", sm: "auto" },
+                "& .MuiButton-root": {
+                  maxWidth: { xs: "100%", sm: 260 },
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  px: 1.5,
+                },
+              }}
+            >
               <DownloadButton
                 disabled={!hasReviewer}
                 url={REVIEWER_ASSIGNMENT.path}
@@ -381,7 +394,7 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
                 }}
                 filename={`${REVIEWER_ASSIGNMENT.filename}_${process?.reviewer_fullname || ""}.${REVIEWER_ASSIGNMENT.extention}`}
               />
-            </span>
+            </Box>
           </Tooltip>
         </Paper>
 
@@ -389,7 +402,10 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
           elevation={0}
           sx={{
             display: "flex",
-            alignItems: "center",
+            flexWrap: "wrap",
+            flexDirection: { xs: "column", sm: "row" },
+            alignItems: { xs: "stretch", sm: "center" },
+            gap: 1.5,
             backgroundColor: "#e6f4ff",
             p: 2,
             borderRadius: 2,
@@ -406,10 +422,20 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
           <Typography variant="body2" sx={{ flexGrow: 1 }}>
             {"Carta de Aprobación de Revisor Presentada\r"}
           </Typography>
-          <Tooltip
-            title={!hasReviewer ? "Debe seleccionar un revisor para habilitar esta descarga" : ""}
-          >
-            <span>
+          <Tooltip title={!hasReviewer ? "Debe seleccionar un revisor para habilitar esta descarga" : ""}>
+            <Box
+              sx={{
+                minWidth: 0,
+                width: { xs: "100%", sm: "auto" },
+                "& .MuiButton-root": {
+                  maxWidth: { xs: "100%", sm: 260 },
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  px: 1.5,
+                },
+              }}
+            >
               <DownloadButton
                 disabled={!hasReviewer}
                 url={TUTOR_APPROBAL.path}
@@ -430,7 +456,7 @@ const ReviewerStage: FC<ReviewerStageProps> = ({ onPrevious, onNext }) => {
                 }}
                 filename={`${TUTOR_APPROBAL.filename}_${process?.reviewer_fullname || formik.values.reviewer}.${TUTOR_APPROBAL.extention}`}
               />
-            </span>
+            </Box>
           </Tooltip>
         </Paper>
 


### PR DESCRIPTION
# fix(graduation): Proceso de Graduación responsive (Etapa 2 y 3: cards y botón Descargar)
 
Como desarrollador frontend quiero que el módulo de *Procesos de Graduación* se visualice correctamente en pantallas pequeñas, evitando la **superposición de cards** y que el **contenido del botón Descargar** sobresalga de su contenedor, para garantizar una experiencia responsive consistente y accesible.

## Criterios de aceptación 
- [x] El **botón Descargar** no sobresale del contenedor.
- [x] En desktop se mantiene el layout actual (dos columnas) sin regresiones.

###  Archivos modificados
- `src/components/stages/ReviewerStage.tsx`  
- `src/components/stages/DocumentCheckbox.tsx`  

###  Cambios realizados
  - `src/components/stages/ReviewerStage.tsx`  
    - **Grid responsive** para los campos de cabecera (selector de revisor y fecha): `xs={12}`, `md={6}` para apilarse en móvil y dividirse 50/50 en desktop.  
    - **Cards** (`<Paper>`) con `display: "flex"`, `flexWrap: "wrap"`, `flexDirection: { xs: "column", sm: "row" }`, `alignItems: { xs: "stretch", sm: "center" }` y `gap` para evitar solapamientos en pantallas reducidas.  
    - **Botón Descargar sin overflow**: wrapper con `minWidth: 0`, `width: { xs: "100%", sm: "auto" }` y reglas para `& .MuiButton-root` (`maxWidth`, `overflow: "hidden"`, `textOverflow: "ellipsis"`, `whiteSpace: "nowrap"`, `px: 1.5`).  
    - **Sin refactors ni nuevas dependencias**; únicamente `sx`/grid para cumplir los criterios.

  - `src/components/stages/DocumentCheckbox.tsx`  
    - Se replica el mismo patrón responsive en las **dos cards** de Etapa 2 (Asignación y Aprobación de Tutor).  
    - La **segunda card** ahora también usa `flexWrap`, dirección responsive y el **wrapper** para truncar el texto del botón y evitar overflow en XS.  

### Postman
> **No aplica** (cambio exclusivo de UI en frontend).  

### Validación manual (equivalente a "Requests configurados")
1. Iniciar sesión y navegar a **Procesos de Graduación**.  
2. Abrir un proceso con **Etapa 2 (Seleccionar Tutor)** y **Etapa 3 (Seleccionar Revisor)**.  
3. Abrir **modo inspección** y simular vistas: 320px, 375px, 414px, 768px, 1024px.  
4. Validar:
   - Las **cards** no se sobreponen (se apilan en `xs` y se ordenan en fila en `sm+`).  
   - El **botón Descargar** ocupa el espacio disponible y **no** se desborda; en `xs`, el texto se trunca con **ellipsis**.  
   - En desktop (≥1024px) se mantiene el layout habitual (dos columnas) sin cambios visuales no deseados.

---

### Notas
- Cambios **idempotentes** que no afectan lógica de negocio ni navegación entre etapas.
- Si se detectan cards similares en otras etapas, se puede replicar el mismo `sx` en un PR separado para mantener este ticket enfocado.
- **Sin impacto** en performance ni dependencias.
